### PR TITLE
Code linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-.gitignore
-/target
-scripts/__pycache__/
+target
+*.pyc
 mint.params
 spend.params

--- a/lisp/README.md
+++ b/lisp/README.md
@@ -1,6 +1,6 @@
 ## zklisp
 
-This is a DSL for ZKVMCircuit from drk language.
+This is a DSL for ZkVmCircuit from drk language.
 
 It uses the mal (lisp) version of rust with some modifications to interact with bellman backend and also drk vm.
 

--- a/lisp/TODO.md
+++ b/lisp/TODO.md
@@ -2,6 +2,6 @@
 
 - Document the language
 - Integrate with zkvm command line
-- Integrate with ZKVMCircuit: allocs and constraints
+- Integrate with ZkVmCircuit: allocs and constraints
 - Added CryptoOperation such double and square to core.rs
-- Adapt ZKContract to use lisp to read contract and execute
+- Adapt ZkContract to use lisp to read contract and execute

--- a/scripts/compile_export_rust.py
+++ b/scripts/compile_export_rust.py
@@ -7,7 +7,7 @@ def to_initial_caps(snake_str):
 def display(contract):
     indent = " " * 4
 
-    print(r"""use super::vm::{ZKVirtualMachine, CryptoOperation, AllocType, ConstraintInstruction, VariableIndex, VariableRef};
+    print(r"""use super::vm::{ZkVirtualMachine, CryptoOperation, AllocType, ConstraintInstruction, VariableIndex, VariableRef};
 use bls12_381::Scalar;
 
 pub fn load_params(params: Vec<Scalar>) -> Vec<(VariableIndex, Scalar)> {""")
@@ -23,8 +23,8 @@ pub fn load_params(params: Vec<Scalar>) -> Vec<(VariableIndex, Scalar)> {""")
     print("%sresult" % indent)
     print("}\n")
 
-    print(r"""pub fn load_zkvm() -> ZKVirtualMachine {
-    ZKVirtualMachine {
+    print(r"""pub fn load_zkvm() -> ZkVirtualMachine {
+    ZkVirtualMachine {
         constants: vec![""")
 
     constants = list(contract.constants.items())

--- a/src/bin/darkfid.rs
+++ b/src/bin/darkfid.rs
@@ -13,7 +13,7 @@ use drk::service::{GatewayClient, GatewaySlabsSubscriber};
 use drk::state::{state_transition, ProgramState, StateUpdate};
 use drk::util;
 use drk::util::join_config_path;
-use drk::wallet::{WalletDB, WalletPtr};
+use drk::wallet::{WalletDb, WalletPtr};
 use drk::{tx, Result};
 use log::*;
 use std::fs;
@@ -193,7 +193,7 @@ async fn start(executor: Arc<Executor<'_>>, config: Arc<&DarkfidConfig>) -> Resu
     let merkle_roots = RocksColumn::<columns::MerkleRoots>::new(rocks.clone());
     let nullifiers = RocksColumn::<columns::Nullifiers>::new(rocks);
 
-    let wallet = Arc::new(WalletDB::new("wallet.db", config.password.clone())?);
+    let wallet = Arc::new(WalletDb::new("wallet.db", config.password.clone())?);
 
     let ex = executor.clone();
 

--- a/src/bin/jubjub.rs
+++ b/src/bin/jubjub.rs
@@ -1,5 +1,5 @@
 use bls12_381::Scalar;
-use drk::{BlsStringConversion, Decodable, Encodable, ZKContract, ZKProof};
+use drk::{BlsStringConversion, Decodable, Encodable, ZkContract, ZkProof};
 use std::fs::File;
 use std::time::Instant;
 
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
 
         let start = Instant::now();
         let file = File::open("jubjub.zcd")?;
-        let mut contract = ZKContract::decode(file)?;
+        let mut contract = ZkContract::decode(file)?;
         println!(
             "Loaded contract '{}': [{:?}]",
             contract.name,
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
 
     let start = Instant::now();
     let file = File::open("jubjub.zcd")?;
-    let mut contract = ZKContract::decode(file)?;
+    let mut contract = ZkContract::decode(file)?;
     println!(
         "Loaded contract '{}': [{:?}]",
         contract.name,
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
     // Verify the proof
 
     let file = File::open("jubjub.prf")?;
-    let proof = ZKProof::decode(file)?;
+    let proof = ZkProof::decode(file)?;
     assert!(contract.verify(&proof));
 
     Ok(())

--- a/src/bin/mimc.rs
+++ b/src/bin/mimc.rs
@@ -1,6 +1,6 @@
 use bls12_381::Scalar;
 use ff::Field;
-use drk::{Decodable, ZKContract};
+use drk::{Decodable, ZkContract};
 use std::fs::File;
 use std::ops::{Add, AddAssign, MulAssign, Neg, SubAssign};
 use std::time::Instant;
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
 
     let start = Instant::now();
     let file = File::open("mimc.zcd")?;
-    let mut contract = ZKContract::decode(file)?;
+    let mut contract = ZkContract::decode(file)?;
     println!(
         "Loaded contract '{}': [{:?}]",
         contract.name,

--- a/src/bin/mint.rs
+++ b/src/bin/mint.rs
@@ -1,4 +1,4 @@
-use drk::{Decodable, ZKContract};
+use drk::{Decodable, ZkContract};
 use std::fs::File;
 use std::time::Instant;
 
@@ -42,9 +42,9 @@ fn _unpack_u64(value: u64) -> Vec<Scalar> {
 fn main() -> Result<()> {
     let start = Instant::now();
     let file = File::open("mint.zcd")?;
-    let mut visor = ZKContract::decode(file)?;
+    let mut visor = ZkContract::decode(file)?;
     println!("{}", visor.name);
-    //ZKContract::load_contract(bytes);
+    //ZkContract::load_contract(bytes);
     println!("Loaded contract: [{:?}]", start.elapsed());
 
     println!("Stats:");

--- a/src/bin/tutorial.rs
+++ b/src/bin/tutorial.rs
@@ -1,7 +1,7 @@
 // This tutorial example corresponds to the VM proof in proofs/tutorial.psm
 // It encodes the same function as the one in zk-explainer document.
 use bls12_381::Scalar;
-use drk::{BlsStringConversion, Decodable, Encodable, ZKContract, ZKProof};
+use drk::{BlsStringConversion, Decodable, Encodable, ZkContract, ZkProof};
 use std::fs::File;
 use std::time::Instant;
 
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
 
         let start = Instant::now();
         let file = File::open("tutorial.zcd")?;
-        let mut contract = ZKContract::decode(file)?;
+        let mut contract = ZkContract::decode(file)?;
         println!(
             "Loaded contract '{}': [{:?}]",
             contract.name,
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
 
     let start = Instant::now();
     let file = File::open("tutorial.zcd")?;
-    let mut contract = ZKContract::decode(file)?;
+    let mut contract = ZkContract::decode(file)?;
     println!(
         "Loaded contract '{}': [{:?}]",
         contract.name,
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
     // Verify the proof
 
     let file = File::open("tutorial.prf")?;
-    let proof = ZKProof::decode(file)?;
+    let proof = ZkProof::decode(file)?;
     assert!(contract.verify(&proof));
 
     Ok(())

--- a/src/bin/zkvm.rs
+++ b/src/bin/zkvm.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate clap;
 use bls12_381::Scalar;
-use drk::{BlsStringConversion, Decodable, Encodable, ZKContract, ZKProof};
+use drk::{BlsStringConversion, Decodable, Encodable, ZkContract, ZkProof};
 use simplelog::*;
 use std::fs;
 use std::fs::File;
@@ -14,7 +14,7 @@ type Result<T> = std::result::Result<T, failure::Error>;
 fn trusted_setup(contract_data: String, setup_file: String) -> Result<()> {
     let start = Instant::now();
     let file = File::open(contract_data)?;
-    let mut contract = ZKContract::decode(file)?;
+    let mut contract = ZkContract::decode(file)?;
     println!(
         "loaded contract '{}': [{:?}]",
         contract.name,
@@ -41,7 +41,7 @@ fn create_proof(
 ) -> Result<()> {
     let start = Instant::now();
     let file = File::open(contract_data)?;
-    let mut contract = ZKContract::decode(file)?;
+    let mut contract = ZkContract::decode(file)?;
     contract.load_setup(&setup_file)?;
     println!(
         "Loaded contract '{}': [{:?}]",
@@ -66,10 +66,10 @@ fn create_proof(
 //verify the proof
 fn verify_proof(contract_data: String, setup_file: String, zk_proof: String) -> Result<()> {
     let contract_file = File::open(contract_data)?;
-    let mut contract = ZKContract::decode(contract_file)?;
+    let mut contract = ZkContract::decode(contract_file)?;
     contract.load_setup(&setup_file)?;
     let proof_file = File::open(zk_proof)?;
-    let proof = ZKProof::decode(proof_file)?;
+    let proof = ZkProof::decode(proof_file)?;
     if contract.verify(&proof) {
         println!("Zero-knowledge proof verified correctly.")
     } else {
@@ -81,7 +81,7 @@ fn verify_proof(contract_data: String, setup_file: String, zk_proof: String) -> 
 // show public values in proof
 fn show_public(zk_proof: String) -> Result<()> {
     let file = File::open(zk_proof)?;
-    let proof = ZKProof::decode(file)?;
+    let proof = ZkProof::decode(file)?;
     //assert_eq!(proof.public.len(), 2);
     println!("Public values: {:?}", proof.public);
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,10 @@
 // TODO: Add support for rusqlite error
 use jsonrpc_core::*;
-use rusqlite;
+//use rusqlite;
 use std::fmt;
 
 use crate::state;
-use crate::vm::ZKVMError;
+use crate::vm::ZkVmError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -25,7 +25,7 @@ pub enum Error {
     BadConstraintType,
     InvalidParamName,
     MissingParams,
-    VMError,
+    VmError,
     BadContract,
     Groth16Error,
     RusqliteError(String),
@@ -39,7 +39,7 @@ pub enum Error {
     StrUtf8Error(String),
     NoteDecryptionFailed,
     ServicesError(&'static str),
-    ZMQError(String),
+    ZmqError(String),
     VerifyFailed,
     TryIntoError,
     TryFromError,
@@ -71,7 +71,7 @@ impl fmt::Display for Error {
             Error::BadConstraintType => f.write_str("Bad constraint type byte"),
             Error::InvalidParamName => f.write_str("Invalid param name"),
             Error::MissingParams => f.write_str("Missing params"),
-            Error::VMError => f.write_str("VM error"),
+            Error::VmError => f.write_str("VM error"),
             Error::BadContract => f.write_str("Contract is poorly defined"),
             Error::Groth16Error => f.write_str("Groth16 error"),
             Error::RusqliteError(ref err) => write!(f, "Rusqlite error {}", err),
@@ -86,7 +86,7 @@ impl fmt::Display for Error {
             Error::StrUtf8Error(ref err) => write!(f, "Malformed UTF8: {}", err),
             Error::NoteDecryptionFailed => f.write_str("Unable to decrypt mint note"),
             Error::ServicesError(ref err) => write!(f, "Services error: {}", err),
-            Error::ZMQError(ref err) => write!(f, "ZMQError: {}", err),
+            Error::ZmqError(ref err) => write!(f, "ZmqError: {}", err),
             Error::VerifyFailed => f.write_str("Verify failed"),
             Error::TryIntoError => f.write_str("TryInto error"),
             Error::TryFromError => f.write_str("TryFrom error"),
@@ -105,7 +105,7 @@ impl fmt::Display for Error {
 // TODO: Match statement to parse external errors into strings.
 impl From<zeromq::ZmqError> for Error {
     fn from(err: zeromq::ZmqError) -> Error {
-        Error::ZMQError(err.to_string())
+        Error::ZmqError(err.to_string())
     }
 }
 
@@ -146,9 +146,9 @@ impl From<rusqlite::Error> for Error {
     }
 }
 
-impl From<ZKVMError> for Error {
-    fn from(_err: ZKVMError) -> Error {
-        Error::VMError
+impl From<ZkVmError> for Error {
+    fn from(_err: ZkVmError) -> Error {
+        Error::VmError
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,26 +29,26 @@ pub use crate::error::{Error, Result};
 pub use crate::net::p2p::P2p;
 pub use crate::serial::{Decodable, Encodable};
 pub use crate::vm::{
-    AllocType, ConstraintInstruction, CryptoOperation, VariableIndex, VariableRef, ZKVMCircuit,
-    ZKVirtualMachine,
+    AllocType, ConstraintInstruction, CryptoOperation, VariableIndex, VariableRef, ZkVmCircuit,
+    ZkVirtualMachine,
 };
 
 pub type Bytes = Vec<u8>;
 
-pub struct ZKContract {
+pub struct ZkContract {
     pub name: String,
-    pub vm: ZKVirtualMachine,
+    pub vm: ZkVirtualMachine,
     params_map: HashMap<String, VariableIndex>,
     pub params: HashMap<VariableIndex, Scalar>,
     public_map: bimap::BiMap<String, VariableIndex>,
 }
 
-pub struct ZKProof {
+pub struct ZkProof {
     pub public: HashMap<String, Scalar>,
     pub proof: groth16::Proof<Bls12>,
 }
 
-impl ZKContract {
+impl ZkContract {
     // Just have a load() and save()
     // Load the contract, do the setup, save it...
 
@@ -82,7 +82,7 @@ impl ZKContract {
         }
     }
 
-    pub fn prove(&mut self) -> Result<ZKProof> {
+    pub fn prove(&mut self) -> Result<ZkProof> {
         // Error if params not all set
         let user_params: HashSet<_> = self.params.keys().collect();
         let req_params: HashSet<_> = self.params_map.values().collect();
@@ -108,9 +108,9 @@ impl ZKContract {
         }
 
         // return proof and public values (Hashmap string -> scalars)
-        Ok(ZKProof { public, proof })
+        Ok(ZkProof { public, proof })
     }
-    pub fn verify(&self, proof: &ZKProof) -> bool {
+    pub fn verify(&self, proof: &ZkProof) -> bool {
         let mut public = vec![];
         for (name, value) in &proof.public {
             match self.public_map.get_by_left(name) {

--- a/src/net/message_subscriber.rs
+++ b/src/net/message_subscriber.rs
@@ -13,13 +13,13 @@ use crate::net::messages::Message;
 use crate::serial::{Decodable, Encodable};
 
 /// 64bit identifier for message subscription.
-pub type MessageSubscriptionID = u64;
+pub type MessageSubscriptionId = u64;
 type MessageResult<M> = Result<Arc<M>>;
 
 /// Handles message subscriptions through a subscription ID and a receiver
 /// channel.
 pub struct MessageSubscription<M: Message> {
-    id: MessageSubscriptionID,
+    id: MessageSubscriptionId,
     recv_queue: async_channel::Receiver<MessageResult<M>>,
     parent: Arc<MessageDispatcher<M>>,
 }
@@ -54,7 +54,7 @@ trait MessageDispatcherInterface: Send + Sync {
 /// Maintains a list of active subscribers and handles sending messages across
 /// subscriptions.
 struct MessageDispatcher<M: Message> {
-    subs: Mutex<HashMap<MessageSubscriptionID, async_channel::Sender<MessageResult<M>>>>,
+    subs: Mutex<HashMap<MessageSubscriptionId, async_channel::Sender<MessageResult<M>>>>,
 }
 
 impl<M: Message> MessageDispatcher<M> {
@@ -66,7 +66,7 @@ impl<M: Message> MessageDispatcher<M> {
     }
 
     /// Create a random ID.
-    fn random_id() -> MessageSubscriptionID {
+    fn random_id() -> MessageSubscriptionId {
         let mut rng = rand::thread_rng();
         rng.gen()
     }
@@ -87,7 +87,7 @@ impl<M: Message> MessageDispatcher<M> {
 
     /// Unsubcribe from a channel. Removes the associated ID from the subscriber
     /// list.
-    async fn unsubscribe(&self, sub_id: MessageSubscriptionID) {
+    async fn unsubscribe(&self, sub_id: MessageSubscriptionId) {
         self.subs.lock().await.remove(&sub_id);
     }
 
@@ -125,7 +125,7 @@ impl<M: Message> MessageDispatcher<M> {
     }
 
     /// Remove inactive channels.
-    async fn collect_garbage(&self, ids: Vec<MessageSubscriptionID>) {
+    async fn collect_garbage(&self, ids: Vec<MessageSubscriptionId>) {
         let mut subs = self.subs.lock().await;
         for id in &ids {
             subs.remove(id);

--- a/src/old/bits.rs
+++ b/src/old/bits.rs
@@ -4,7 +4,7 @@ mod bits_contract;
 mod vm;
 use bits_contract::load_zkvm;
 
-fn main() -> std::result::Result<(), vm::ZKVMError> {
+fn main() -> std::result::Result<(), vm::ZkVmError> {
     let mut vm = load_zkvm();
 
     vm.setup();

--- a/src/old/mint2.rs
+++ b/src/old/mint2.rs
@@ -57,7 +57,7 @@ fn do_vcr_test(value: &jubjub::Fr) {
     println!("cvr2: {:?}", randomness_commit);
 }
 
-fn main() -> std::result::Result<(), vm::ZKVMError> {
+fn main() -> std::result::Result<(), vm::ZkVmError> {
     use rand::rngs::OsRng;
     let public_point = jubjub::ExtendedPoint::from(jubjub::SubgroupPoint::random(&mut OsRng));
     let public_affine = public_point.to_affine();

--- a/src/old/zkmimc.rs
+++ b/src/old/zkmimc.rs
@@ -40,7 +40,7 @@ macro_rules! from_slice {
     }};
 }
 
-fn main() -> std::result::Result<(), vm::ZKVMError> {
+fn main() -> std::result::Result<(), vm::ZkVmError> {
     use rand::rngs::OsRng;
 
     /////////////////////////////////

--- a/src/rpc/adapter.rs
+++ b/src/rpc/adapter.rs
@@ -1,4 +1,4 @@
-use crate::wallet::WalletDB;
+use crate::wallet::WalletDb;
 use crate::Result;
 use async_std::sync::Arc;
 use log::*;
@@ -7,11 +7,11 @@ use log::*;
 pub type AdapterPtr = Arc<RpcAdapter>;
 // Dummy adapter for now
 pub struct RpcAdapter {
-    pub wallet: Arc<WalletDB>,
+    pub wallet: Arc<WalletDb>,
 }
 
 impl RpcAdapter {
-    pub fn new(wallet: Arc<WalletDB>) -> Result<Self> {
+    pub fn new(wallet: Arc<WalletDb>) -> Result<Self> {
         debug!(target: "ADAPTER", "new() [CREATING NEW WALLET]");
         Ok(Self { wallet })
     }
@@ -71,15 +71,15 @@ impl RpcAdapter {
     //pub async fn create_
     //pub async fn save_key(&self, pubkey: Vec<u8>) -> Result<()> {
     //    debug!(target: "adapter", "save_key() [START]");
-    //    //let path = WalletDB::path("wallet.db")?;
-    //    //WalletDB::save(path, pubkey).await?;
+    //    //let path = WalletDb::path("wallet.db")?;
+    //    //WalletDb::save(path, pubkey).await?;
     //    Ok(())
     //}
 
     //pub async fn save_cash_key(&self, pubkey: Vec<u8>) -> Result<()> {
     //    debug!(target: "adapter", "save_cash_key() [START]");
-    //    //let path = WalletDB::path("cashier.db")?;
-    //    //WalletDB::save(path, pubkey).await?;
+    //    //let path = WalletDb::path("cashier.db")?;
+    //    //WalletDb::save(path, pubkey).await?;
     //    Ok(())
     //}
 

--- a/src/service/reqrep.rs
+++ b/src/service/reqrep.rs
@@ -184,7 +184,7 @@ impl ReqProtocol {
 
             Ok(Some(reply.get_payload()))
         } else {
-            Err(crate::Error::ZMQError(
+            Err(crate::Error::ZmqError(
                 "Couldn't parse ZmqMessage".to_string(),
             ))
         }
@@ -263,7 +263,7 @@ impl Subscriber {
                 let data: T = deserialize(&data)?;
                 Ok(data)
             }
-            None => Err(crate::Error::ZMQError(
+            None => Err(crate::Error::ZmqError(
                 "Couldn't parse ZmqMessage".to_string(),
             )),
         }

--- a/src/system/subscriber.rs
+++ b/src/system/subscriber.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 
 pub type SubscriberPtr<T> = Arc<Subscriber<T>>;
 
-pub type SubscriptionID = u64;
+pub type SubscriptionId = u64;
 
 pub struct Subscription<T> {
-    id: SubscriptionID,
+    id: SubscriptionId,
     recv_queue: async_channel::Receiver<T>,
     parent: Arc<Subscriber<T>>,
 }
@@ -43,7 +43,7 @@ impl<T: Clone> Subscriber<T> {
         })
     }
 
-    fn random_id() -> SubscriptionID {
+    fn random_id() -> SubscriptionId {
         let mut rng = rand::thread_rng();
         rng.gen()
     }
@@ -62,7 +62,7 @@ impl<T: Clone> Subscriber<T> {
         }
     }
 
-    async fn unsubscribe(self: Arc<Self>, sub_id: SubscriptionID) {
+    async fn unsubscribe(self: Arc<Self>, sub_id: SubscriptionId) {
         self.subs.lock().await.remove(&sub_id);
     }
 

--- a/src/vm_serial.rs
+++ b/src/vm_serial.rs
@@ -1,9 +1,9 @@
 use crate::error::{Error, Result};
 use crate::serial::{Decodable, Encodable, ReadExt, VarInt};
 use crate::vm::{
-    AllocType, ConstraintInstruction, CryptoOperation, VariableIndex, VariableRef, ZKVirtualMachine,
+    AllocType, ConstraintInstruction, CryptoOperation, VariableIndex, VariableRef, ZkVirtualMachine,
 };
-use crate::{impl_vec, ZKContract, ZKProof};
+use crate::{impl_vec, ZkContract, ZkProof};
 use bellman::groth16;
 use bls12_381 as bls;
 use std::collections::HashMap;
@@ -12,18 +12,18 @@ use std::io;
 impl_vec!((String, VariableIndex));
 impl_vec!((String, bls::Scalar));
 
-impl Encodable for ZKContract {
+impl Encodable for ZkContract {
     fn encode<S: io::Write>(&self, _s: S) -> Result<usize> {
         unimplemented!();
         //Ok(0)
     }
 }
 
-impl Decodable for ZKContract {
+impl Decodable for ZkContract {
     fn decode<D: io::Read>(mut d: D) -> Result<Self> {
         Ok(Self {
             name: Decodable::decode(&mut d)?,
-            vm: ZKVirtualMachine {
+            vm: ZkVirtualMachine {
                 constants: Decodable::decode(&mut d)?,
                 alloc: Decodable::decode(&mut d)?,
                 ops: Decodable::decode(&mut d)?,
@@ -45,7 +45,7 @@ impl Decodable for ZKContract {
     }
 }
 
-impl Encodable for ZKProof {
+impl Encodable for ZkProof {
     fn encode<S: io::Write>(&self, mut s: S) -> Result<usize> {
         let mut len = self
             .public
@@ -58,7 +58,7 @@ impl Encodable for ZKProof {
     }
 }
 
-impl Decodable for ZKProof {
+impl Decodable for ZkProof {
     fn decode<D: io::Read>(mut d: D) -> Result<Self> {
         Ok(Self {
             public: Vec::<(String, bls::Scalar)>::decode(&mut d)?

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1,3 +1,3 @@
 pub mod walletdb;
 
-pub use walletdb::{WalletDB, WalletPtr};
+pub use walletdb::{WalletDb, WalletPtr};

--- a/src/wallet/walletdb.rs
+++ b/src/wallet/walletdb.rs
@@ -12,9 +12,9 @@ use rusqlite::{named_params, params, Connection};
 
 use std::path::PathBuf;
 
-pub type WalletPtr = Arc<WalletDB>;
+pub type WalletPtr = Arc<WalletDb>;
 
-pub struct WalletDB {
+pub struct WalletDb {
     pub path: PathBuf,
     pub secrets: Vec<jubjub::Fr>,
     pub cashier_secrets: Vec<jubjub::Fr>,
@@ -26,7 +26,7 @@ pub struct WalletDB {
     pub password: String,
 }
 
-impl WalletDB {
+impl WalletDb {
     pub fn new(wallet: &str, password: String) -> Result<Self> {
         debug!(target: "walletdb", "new() Constructor called");
         let path = join_config_path(&PathBuf::from(wallet))?;


### PR DESCRIPTION
For best and standard practices in Rust, acronyms should be CamelCase,
and capitalization should be avoided; i.e. ZKCircuit -> ZkCircuit

This commit replaces all such occurencies in the codebase.