### PR TITLE
book/tutorial: fixing url

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -107,7 +107,7 @@ tutorial](https://bitzuma.com/posts/a-beginners-guide-to-the-electrum-bitcoin-wa
 for more details.
 
 For Solana, you can either install the Solana command-line suite or use
-[sollet](sollet.io).
+[sollet](https://www.sollet.io).
 
 Follow [this tutorial](https://docs.solana.com/cli) for the Solana
 command-line. For sollet.io, switch the network to testnet and click


### PR DESCRIPTION
Pointing sollet URL to https://www.sollet.io instead of sollet.io which points to https://darkrenaissance.github.io/darkfi/sollet.io which is nowhere.