### PR TITLE
bin/ircd: update & fix clap app deprication and log configuration

### DIFF
--- a/bin/dao-cli/src/main.rs
+++ b/bin/dao-cli/src/main.rs
@@ -58,7 +58,7 @@ async fn start(options: CliDao) -> Result<()> {
         Some(CliDaoSubCommands::Hello {}) => {
             let reply = client.say_hello().await?;
             println!("Server replied: {}", &reply.to_string());
-            return Ok(());
+            return Ok(())
         }
         None => {}
     }

--- a/bin/daod/src/main.rs
+++ b/bin/daod/src/main.rs
@@ -40,7 +40,7 @@ struct JsonRpcInterface {}
 impl RequestHandler for JsonRpcInterface {
     async fn handle_request(&self, req: JsonRequest, _executor: Arc<Executor<'_>>) -> JsonResult {
         if req.params.as_array().is_none() {
-            return JsonResult::Err(jsonerr(InvalidParams, None, req.id));
+            return JsonResult::Err(jsonerr(InvalidParams, None, req.id))
         }
 
         debug!(target: "RPC", "--> {}", serde_json::to_string(&req).unwrap());

--- a/bin/ircd/src/main.rs
+++ b/bin/ircd/src/main.rs
@@ -1,13 +1,11 @@
-#[macro_use]
 extern crate clap;
 use async_executor::Executor;
 use async_std::io::BufReader;
 use async_trait::async_trait;
-use clap::{ArgMatches, IntoApp};
 use futures::{AsyncBufReadExt, AsyncReadExt, FutureExt};
 use log::{debug, error, info, warn};
 use serde_json::{json, Value};
-use simplelog::{ColorChoice, LevelFilter, TermLogger, TerminalMode};
+use simplelog::{ColorChoice, TermLogger, TerminalMode};
 use smol::Async;
 use std::{
     net::{SocketAddr, TcpListener, TcpStream},
@@ -15,7 +13,7 @@ use std::{
 };
 
 use darkfi::{
-    cli::{cli_config::log_config, cli_parser::CliIrcd},
+    cli::cli_config::log_config,
     net,
     rpc::{
         jsonrpc::{error as jsonerr, response as jsonresp, ErrorCode::*, JsonRequest, JsonResult},
@@ -245,21 +243,10 @@ impl JsonRpcInterface {
 }
 
 fn main() -> Result<()> {
-    //let matches = CliIrcd::into_app().get_matches();
-    //let conf: simplelog::Config;
-    //let lvl: LevelFilter;
-
-    //let (lvl, conf) = log_config(matches)?;
-
-    //TermLogger::init(lvl, conf, TerminalMode::Mixed, ColorChoice::Auto)?;
-    TermLogger::init(
-        LevelFilter::Debug,
-        simplelog::Config::default(),
-        TerminalMode::Mixed,
-        ColorChoice::Auto,
-    )?;
-
     let options = ProgramOptions::load()?;
+    let (lvl, cfg) = log_config(options.app.clone())?;
+
+    TermLogger::init(lvl, cfg, TerminalMode::Mixed, ColorChoice::Auto)?;
 
     let ex = Arc::new(Executor::new());
     smol::block_on(ex.run(start(ex.clone(), options)))

--- a/bin/ircd/src/program_options.rs
+++ b/bin/ircd/src/program_options.rs
@@ -1,3 +1,4 @@
+use clap::{App, Arg, ArgMatches};
 use std::net::SocketAddr;
 
 use darkfi::{net, Result};
@@ -7,24 +8,84 @@ pub struct ProgramOptions {
     pub log_path: Box<std::path::PathBuf>,
     pub irc_accept_addr: SocketAddr,
     pub rpc_listen_addr: SocketAddr,
+    pub app: ArgMatches,
 }
 
 impl ProgramOptions {
     pub fn load() -> Result<ProgramOptions> {
-        let app = clap_app!(dfi =>
-            (version: "0.1.0")
-            (author: "Amir Taaki <amir@dyne.org>")
-            (about: "Dark node")
-            (@arg ACCEPT: -a --accept +takes_value "Accept address")
-            (@arg SEED_NODES: -s --seeds +takes_value ... "Seed nodes")
-            (@arg CONNECTS: -c --connect +takes_value ... "Manual connections")
-            (@arg CONNECT_SLOTS: --slots +takes_value "Connection slots")
-            (@arg EXTERNAL_ADDR: -e --external +takes_value "External address")
-            (@arg LOG_PATH: --log +takes_value "Logfile path")
-            (@arg IRC_ACCEPT: -r --irc +takes_value "IRC accept address")
-            (@arg RPC_LISTEN: --rpc +takes_value "RPC listen address")
-        )
-        .get_matches();
+        let app = App::new("dfi")
+            .version("0.1.0")
+            .author("Amir Taaki <amir@dyne.org>")
+            .about("Dark node")
+            .arg(
+                Arg::new("ACCEPT")
+                    .short('a')
+                    .long("accept")
+                    .value_name("ACCEPT")
+                    .help("Accept address")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("SEED_NODES")
+                    .short('s')
+                    .long("seeds")
+                    .value_name("SEED_NODES")
+                    .help("Seed nodes")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("CONNECTS")
+                    .short('c')
+                    .long("connect")
+                    .value_name("CONNECTS")
+                    .help("Manual connections")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("CONNECT_SLOTS")
+                    .long("slots")
+                    .value_name("CONNECT_SLOTS")
+                    .help("Connection slots")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("EXTERNAL_ADDR")
+                    .short('e')
+                    .long("external")
+                    .value_name("EXTERNAL_ADDR")
+                    .help("External address")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("LOG_PATH")
+                    .long("log")
+                    .value_name("LOG_PATH")
+                    .help("Logfile path")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("IRC_ACCEPT")
+                    .short('r')
+                    .long("irc")
+                    .value_name("IRC_ACCEPT")
+                    .help("IRC accept address")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("RPC_LISTEN")
+                    .long("rpc")
+                    .value_name("RPC_LISTEN")
+                    .help("RPC listen address")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::new("verbose")
+                    .short('v')
+                    .long("verbose")
+                    .multiple_occurrences(true)
+                    .help("Sets the level of verbosity"),
+            )
+            .get_matches();
 
         let accept_addr = if let Some(accept_addr) = app.value_of("ACCEPT") {
             Some(accept_addr.parse()?)
@@ -91,6 +152,7 @@ impl ProgramOptions {
             log_path,
             irc_accept_addr,
             rpc_listen_addr,
+            app,
         })
     }
 }

--- a/src/cli/cli_config.rs
+++ b/src/cli/cli_config.rs
@@ -10,7 +10,7 @@ use std::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use clap::ArgMatches;
-use simplelog::{ConfigBuilder, LevelFilter};
+use simplelog::ConfigBuilder;
 
 use crate::{Error, Result};
 
@@ -157,13 +157,13 @@ pub fn spawn_config(path: &Path, contents: &[u8]) -> Result<()> {
     Ok(())
 }
 
-pub fn log_config(matches: ArgMatches) -> Result<(LevelFilter, simplelog::Config)> {
+pub fn log_config(matches: ArgMatches) -> Result<(simplelog::LevelFilter, simplelog::Config)> {
     let mut verbosity_level = 0;
     verbosity_level += matches.occurrences_of("verbose");
     let log_level = match verbosity_level {
-        0 => LevelFilter::Info,
-        1 => LevelFilter::Debug,
-        _ => LevelFilter::Trace,
+        0 => simplelog::LevelFilter::Info,
+        1 => simplelog::LevelFilter::Debug,
+        _ => simplelog::LevelFilter::Trace,
     };
 
     let log_config = match env::var("LOG_TARGETS") {

--- a/src/cli/cli_parser.rs
+++ b/src/cli/cli_parser.rs
@@ -86,9 +86,8 @@ pub enum CliDrkSubCommands {
 #[derive(Subcommand)]
 pub enum CliDaoSubCommands {
     /// Say hello to the RPC
-    Hello {}
+    Hello {},
 }
-
 
 /// Drk cli
 #[derive(Parser)]
@@ -156,15 +155,6 @@ pub struct CliCashierd {
     pub refresh: bool,
 }
 
-/// Ircd cli
-#[derive(Parser)]
-#[clap(name = "ircd")]
-pub struct CliIrcd {
-    /// Increase verbosity
-    #[clap(short, parse(from_occurrences))]
-    pub verbose: u8,
-}
-
 /// DAO cli
 #[derive(Parser)]
 #[clap(name = "dao")]
@@ -175,4 +165,3 @@ pub struct CliDao {
     #[clap(subcommand)]
     pub command: Option<CliDaoSubCommands>,
 }
-

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,4 +3,6 @@ pub mod cli_parser;
 
 pub use cli_config::{CashierdConfig, Config, DarkfidConfig, DrkConfig, GatewaydConfig};
 
-pub use cli_parser::{CliCashierd, CliDarkfid, CliDrk, CliDrkSubCommands, CliGatewayd, CliIrcd, CliDao, CliDaoSubCommands};
+pub use cli_parser::{
+    CliCashierd, CliDao, CliDaoSubCommands, CliDarkfid, CliDrk, CliDrkSubCommands, CliGatewayd,
+};


### PR DESCRIPTION
fixing deprecation of `clap_app!` using clap version 3.0.7 which is used by other binaries in `bin/`
fixing logs filtering in `ircd`