### PR TITLE
swap from ctrlc-async crate to ctrlc crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.zk.bin
 *_circuit_layout.png
 .vscode/
+.DS_Store
 
 /target/*
 /tmp/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,22 +1108,11 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.2"
+version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
+checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
 dependencies = [
- "nix 0.24.2",
- "winapi",
-]
-
-[[package]]
-name = "ctrlc-async"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598e9d68e769aa1283460a3b0ec0d049ccfb6170277aea37089fa3f58fd721a1"
-dependencies = [
- "async-std",
- "nix 0.23.1",
+ "nix",
  "winapi",
 ]
 
@@ -1286,7 +1275,7 @@ dependencies = [
  "blake3",
  "bs58",
  "chrono",
- "ctrlc-async",
+ "ctrlc",
  "darkfi",
  "easy-parallel",
  "futures-lite",
@@ -1351,7 +1340,7 @@ dependencies = [
  "chrono",
  "colored",
  "crypto_box",
- "ctrlc-async",
+ "ctrlc",
  "darkfi",
  "easy-parallel",
  "futures",
@@ -1791,7 +1780,7 @@ dependencies = [
  "blake3",
  "bs58",
  "chrono",
- "ctrlc-async",
+ "ctrlc",
  "darkfi",
  "easy-parallel",
  "futures-lite",
@@ -2356,7 +2345,7 @@ dependencies = [
  "bs58",
  "clap 3.2.16",
  "crypto_box",
- "ctrlc-async",
+ "ctrlc",
  "darkfi",
  "easy-parallel",
  "futures",
@@ -2473,7 +2462,7 @@ dependencies = [
  "async-channel",
  "async-executor",
  "async-std",
- "ctrlc-async",
+ "ctrlc",
  "darkfi",
  "easy-parallel",
  "futures-lite",
@@ -2627,23 +2616,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
 dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
-dependencies = [
+ "autocfg",
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
@@ -4078,7 +4055,7 @@ dependencies = [
  "bs58",
  "chrono",
  "crypto_box",
- "ctrlc-async",
+ "ctrlc",
  "darkfi",
  "easy-parallel",
  "futures",

--- a/bin/darkfid/Cargo.toml
+++ b/bin/darkfid/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1.57"
 blake3 = "1.3.1"
 bs58 = "0.4.0"
 chrono = "0.4.19"
-ctrlc-async = {version = "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 darkfi = {path = "../../", features = ["blockchain", "wallet", "rpc", "net", "node"]}
 easy-parallel = "3.2.0"
 futures-lite = "1.12.0"

--- a/bin/darkfid/src/main.rs
+++ b/bin/darkfid/src/main.rs
@@ -237,8 +237,8 @@ async fn realmain(args: Args, ex: Arc<Executor<'_>>) -> Result<()> {
     // tasks, and to catch a shutdown signal, where we can clean up and
     // exit gracefully.
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
-        signal.send(()).await.unwrap();
+    ctrlc::set_handler(move || {
+        async_std::task::block_on(signal.send(())).unwrap();
     })
     .unwrap();
 

--- a/bin/darkwikid/Cargo.toml
+++ b/bin/darkwikid/Cargo.toml
@@ -31,7 +31,7 @@ simplelog = "0.12.0"
 rand = "0.8.5"
 chrono = "0.4.19"
 thiserror = "1.0.32"
-ctrlc-async = {version= "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 url = "2.2.2"
 fxhash = "0.2.1"
 colored = "2.0.0"

--- a/bin/darkwikid/src/main.rs
+++ b/bin/darkwikid/src/main.rs
@@ -367,10 +367,10 @@ async fn realmain(settings: Args, executor: Arc<Executor<'_>>) -> Result<()> {
     // Waiting Exit signal
     //
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
+    ctrlc::set_handler(move || {
         warn!(target: "darkwiki", "Catch exit signal");
         // cleaning up tasks running in the background
-        if let Err(e) = signal.send(()).await {
+        if let Err(e) = async_std::task::block_on(signal.send(())) {
             error!("Error on sending exit signal: {}", e);
         }
     })

--- a/bin/faucetd/Cargo.toml
+++ b/bin/faucetd/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1.57"
 blake3 = "1.3.1"
 bs58 = "0.4.0"
 chrono = "0.4.19"
-ctrlc-async = {version = "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 darkfi = {path = "../../", features = ["blockchain", "wallet", "rpc", "net", "node"]}
 easy-parallel = "3.2.0"
 futures-lite = "1.12.0"

--- a/bin/faucetd/src/main.rs
+++ b/bin/faucetd/src/main.rs
@@ -299,8 +299,8 @@ async fn realmain(args: Args, ex: Arc<Executor<'_>>) -> Result<()> {
     // tasks, and to catch a shutdown signal, where we can clean up and
     // exit gracefully.
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
-        signal.send(()).await.unwrap();
+    ctrlc::set_handler(move || {
+        async_std::task::block_on(signal.send(())).unwrap();
     })
     .unwrap();
 

--- a/bin/irc-raft/Cargo.toml
+++ b/bin/irc-raft/Cargo.toml
@@ -29,7 +29,7 @@ clap = {version = "3.2.16", features = ["derive"]}
 log = "0.4.17"
 simplelog = "0.12.0"
 fxhash = "0.2.1"
-ctrlc-async = {version= "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 url = "2.2.2"
 
 # Encoding and parsing

--- a/bin/irc-raft/src/main.rs
+++ b/bin/irc-raft/src/main.rs
@@ -244,13 +244,13 @@ async fn realmain(settings: Args, executor: Arc<Executor<'_>>) -> Result<()> {
 
     // Run once receive exit signal
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
+    ctrlc::set_handler(move || {
         warn!(target: "ircd", "ircd start Exit Signal");
         // cleaning up tasks running in the background
-        signal.send(()).await.unwrap();
-        rpc_task.cancel().await;
-        irc_task.cancel().await;
-        p2p_run_task.cancel().await;
+        async_std::task::block_on(signal.send(())).unwrap();
+        async_std::task::block_on(rpc_task.cancel());
+        async_std::task::block_on(irc_task.cancel());
+        async_std::task::block_on(p2p_run_task.cancel());
     })
     .unwrap();
 

--- a/bin/ircd/Cargo.toml
+++ b/bin/ircd/Cargo.toml
@@ -32,7 +32,7 @@ clap = {version = "3.2.16", features = ["derive"]}
 log = "0.4.17"
 simplelog = "0.12.0"
 fxhash = "0.2.1"
-ctrlc-async = {version= "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 url = "2.2.2"
 ringbuffer = "0.8.4"
 

--- a/bin/ircd/src/main.rs
+++ b/bin/ircd/src/main.rs
@@ -318,10 +318,10 @@ async fn realmain(settings: Args, executor: Arc<Executor<'_>>) -> Result<()> {
 
     // Run once receive exit signal
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
+    ctrlc::set_handler(move || {
         warn!(target: "ircd", "ircd start Exit Signal");
         // cleaning up tasks running in the background
-        signal.send(()).await.unwrap();
+        async_std::task::block_on(signal.send(())).unwrap();
     })
     .unwrap();
 

--- a/bin/lilith/Cargo.toml
+++ b/bin/lilith/Cargo.toml
@@ -17,7 +17,7 @@ darkfi = {path = "../../", features = ["net"]}
 async-channel = "1.6.1"
 async-executor = "1.4.1"
 async-std = "1.12.0"
-ctrlc-async = {version = "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 easy-parallel = "3.2.0"
 futures-lite = "1.12.0"
 

--- a/bin/lilith/src/main.rs
+++ b/bin/lilith/src/main.rs
@@ -56,8 +56,8 @@ async fn realmain(args: Args, ex: Arc<Executor<'_>>) -> Result<()> {
     // tasks, and to catch a shutdown signal, where we can clean up and
     // exit gracefully.
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
-        signal.send(()).await.unwrap();
+    ctrlc::set_handler(move || {
+        async_std::task::block_on(signal.send(())).unwrap();
     })
     .unwrap();
 

--- a/bin/tau/taud/Cargo.toml
+++ b/bin/tau/taud/Cargo.toml
@@ -28,7 +28,7 @@ simplelog = "0.12.0"
 rand = "0.8.5"
 chrono = "0.4.19"
 thiserror = "1.0.32"
-ctrlc-async = {version= "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 url = "2.2.2"
 fxhash = "0.2.1"
 

--- a/bin/tau/taud/src/main.rs
+++ b/bin/tau/taud/src/main.rs
@@ -223,10 +223,10 @@ async fn realmain(settings: Args, executor: Arc<Executor<'_>>) -> Result<()> {
     // Waiting Exit signal
     //
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
+    ctrlc::set_handler(move || {
         warn!(target: "tau", "Catch exit signal");
         // cleaning up tasks running in the background
-        if let Err(e) = signal.send(()).await {
+        if let Err(e) = async_std::task::block_on(signal.send(())) {
             error!("Error on sending exit signal: {}", e);
         }
     })

--- a/script/research/dhtd/Cargo.toml
+++ b/script/research/dhtd/Cargo.toml
@@ -13,7 +13,7 @@ async-executor = "1.4.1"
 async-std = "1.12.0"
 async-trait = "0.1.57"
 blake3 = "1.3.1"
-ctrlc-async = {version = "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 easy-parallel = "3.2.0"
 futures-lite = "1.12.0"
 log = "0.4.17"

--- a/script/research/dhtd/src/main.rs
+++ b/script/research/dhtd/src/main.rs
@@ -254,8 +254,8 @@ async fn realmain(args: Args, ex: Arc<Executor<'_>>) -> Result<()> {
     // tasks, and to catch a shutdown signal, where we can clean up and
     // exit gracefully.
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
-        signal.send(()).await.unwrap();
+    ctrlc::set_handler(move || {
+        async_std::task::block_on(signal.send(())).unwrap();
     })
     .unwrap();
 

--- a/script/research/fud/fud/Cargo.toml
+++ b/script/research/fud/fud/Cargo.toml
@@ -14,7 +14,7 @@ async-executor = "1.4.1"
 async-std = "1.12.0"
 async-trait = "0.1.57"
 blake3 = "1.3.1"
-ctrlc-async = {version = "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 darkfi = {path = "../../../../", features = ["dht"]}
 easy-parallel = "3.2.0"
 futures-lite = "1.12.0"

--- a/script/research/fud/fud/src/main.rs
+++ b/script/research/fud/fud/src/main.rs
@@ -346,8 +346,8 @@ async fn realmain(args: Args, ex: Arc<Executor<'_>>) -> Result<()> {
     // tasks, and to catch a shutdown signal, where we can clean up and
     // exit gracefully.
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
-        signal.send(()).await.unwrap();
+    ctrlc::set_handler(move || {
+        async_std::task::block_on(signal.send(())).unwrap();
     })
     .unwrap();
 

--- a/script/research/raft-diag/Cargo.toml
+++ b/script/research/raft-diag/Cargo.toml
@@ -23,7 +23,7 @@ simplelog = "0.12.0"
 rand = "0.8.5"
 chrono = "0.4.19"
 thiserror = "1.0.32"
-ctrlc-async = {version= "3.2.2", default-features = false, features = ["async-std", "termination"]}
+ctrlc = { version = "3.2.3", features = ["termination"] }
 url = "2.2.2"
 fxhash = "0.2.1"
 

--- a/script/research/raft-diag/src/main.rs
+++ b/script/research/raft-diag/src/main.rs
@@ -161,10 +161,10 @@ async fn start(args: Args, executor: Arc<Executor<'_>>) -> Result<()> {
     // Waiting Exit signal
     //
     let (signal, shutdown) = async_channel::bounded::<()>(1);
-    ctrlc_async::set_async_handler(async move {
+    ctrlc::set_handler(move || {
         warn!("Catch exit signal");
         // cleaning up tasks running in the background
-        if let Err(e) = signal.send(()).await {
+        if let Err(e) = async_std::task::block_on(signal.send(())) {
             error!("Error on sending exit signal: {}", e);
         }
     })


### PR DESCRIPTION
`ctrlc-async` isn't compatible with macos, which is preventing darkfi binaries from running on macos (https://github.com/darkrenaissance/darkfi/issues/92)

it doesn't seem the async functionality is necessary, so `ctrlc` appears to be a fine substitute