### PR TITLE
`doc/zkas/`: add syntax reference

### DIFF
--- a/doc/src/zkas/bincode.md
+++ b/doc/src/zkas/bincode.md
@@ -39,7 +39,9 @@ Integers in the binary are encoded using variable-integer encoding.
 See [`serial.rs`](https://github.com/darkrenaissance/darkfi/blob/master/src/util/serial.rs)
 for our Rust implementation.
 
-## `MAGIC_BYTES`
+## Sections
+
+### `MAGIC_BYTES`
 
 The magic bytes are the file signature consisting of four bytes used
 to identify the zkas binary code. They consist of:
@@ -47,21 +49,21 @@ to identify the zkas binary code. They consist of:
 > `0x0b` `0xxx` `0xb1` `0x35`
 
 
-## `BINARY_VERSION`
+### `BINARY_VERSION`
 
 The binary code also contains the binary version to allow parsing
 potential different formats in the future.
 
 > `0x01`
 
-## `.constant`
+### `.constant`
 
 The constants in the `.constant` section are declared with their type
 and name, so that the VM knows how to search for the builtin constant
 and add it to the stack.
 
 
-## `.contract`
+### `.contract`
 
 The `.contract` section holds the circuit witness values in the form
 of `WITNESS_TYPE`. Their stack index is incremented for each witness
@@ -71,7 +73,7 @@ will be loaded into the circuit as _private values_ using the Halo2
 `load_private` API.
 
 
-## `.circuit`
+### `.circuit`
 
 The `.circuit` section holds the procedural logic of the ZK proof.
 In here we have statements with opcodes that are executed as
@@ -93,10 +95,62 @@ where:
 In case an opcode has a return value, the value shall be pushed to
 the stack and become available for later references.
 
-## `.debug`
+### `.debug`
 
 TBD
 
+## Syntax Reference
+
+### Types
+
+| Type               | Description                                    |
+| ------------------ | ---------------------------------------------- |
+| `EcPoint`          | Elliptic Curve Point.                          |
+| `EcFixedPoint`     | Elliptic Curve Point (constant).               |
+| `EcFixedPointBase` | Elliptic Curve Point in Base Field (constant). |
+| `Base`             | Base Field Element.                            |
+| `BaseArray`        | Base Field Element Array.                      |
+| `Scalar`           | Scalar Field Element.                          |
+| `ScalarArray`      | Scalar Field Element Array.                    |
+| `MerklePath`       | Merkle Tree Path.                              |
+| `Uint32`           | Unsigned 32 Bit Integer.                       |
+| `Uint64`           | Unsigned 64 Bit Integer.                       |
+
+### Opcodes
+
+| Opcode               | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `EcAdd`              | Elliptic Curve Addition.                                        |
+| `EcMul`              | Elliptic Curve Multiplication.                                  |
+| `EcMulBase`          | Elliptic Curve Multiplication with `Base`.                      |
+| `EcMulShort`         | Elliptic Curve Multiplication with a u64 wrapped in a `Scalar`. |
+| `EcGetX`             | Get X Coordinate of Elliptic Curve Point.                       |
+| `EcGetY`             | Get Y Coordinate of Elliptic Curve Point.                       |
+| `PoseidonHash`       | Poseidon Hash of N Elements.                                    |
+| `CalculateMerkeRoot` | Compute a Merkle Root.                                          |
+| `BaseAdd`            | `Base` Addition.                                                |
+| `BaseMul`            | `Base` Multiplication.                                          |
+| `BaseSub`            | `Base` Subtraction.                                             |
+| `GreaterThan`        | Greater Than Operation of `Base`.                               |
+| `ConstrainInstance`  | Constrain a `Base` to a Circuit's Public Input.                 |
+
+### Built-in Opcode Wrappers
+
+| Opcode                | Function                                                | Return        |
+| --------------------- | ------------------------------------------------------- | ------------- |
+| `EcAdd`               | `ec_add(EcPoint a, EcPoint b)`                          | `(EcPoint c)` |
+| `EcMul`               | `ec_mul(EcPoint a, EcPoint c)`                          | `(EcPoint c)` |
+| `EcMulBase`           | `ec_mul_base(Base a, EcFixedPointBase b)`               | `(EcPoint c)` |
+| `EcMulShort`          | `ec_mul_short(Base a, EcFixedPointShort b)`             | `(EcPoint c)` |
+| `EcGetX`              | `ec_get_x(EcPoint a)`                                   | `(Base x)`    |
+| `EcGetY`              | `ec_get_y(EcPoint a)`                                   | `(Base y)`    |
+| `PoseidonHash`        | `poseidon_hash(Base a, ..., Base n)`                    | `(Base h)`    |
+| `CalculateMerkleRoot` | `calculate_merkle_root(Uint32 i, MerklePath p, Base a)` | `(Base r)`    |
+| `BaseAdd`             | `base_add(Base a, Base b)`                              | `(Base c)`    |
+| `BaseMul`             | `base_mul(Base a, Base b)`                              | `(Base c)`    |
+| `BaseSub`             | `base_sub(Base a, Base b)`                              | `(Base c)`    |
+| `GreaterThan`         | `greater_than(Base a, Base b)`                          | `(Base gt)`   |
+| `ConstrainInstance`   | `constrain_instance(Base a)`                            | `()`          |
 
 ## Decoding the bincode
 


### PR DESCRIPTION
This pull request introduces a minimal, but workable reference to `zkas` data types, opcodes, and built-in opcode wrappers.