### PR TITLE
Improve hashchain docs

### DIFF
--- a/doc/src/misc/hashchain/hashchain.md
+++ b/doc/src/misc/hashchain/hashchain.md
@@ -1,99 +1,99 @@
-# Structures 
+# Structures
 
 ## EventId
 
-Hash of `Event` 
+Hash of `Event`
 
-	type EventId = [u8; 32];	
+```rust
+type EventId = [u8; 32];
+```
 
-## EventAction 
+## EventAction
 
 The `Event` could have many actions according to the underlying data.
 
-	enum EventAction { ... };	
+```rust
+enum EventAction { ... };
+```
 
 ## Event
 
 | Description            | Data Type      | Comments                    |
 |----------------------- | -------------- | --------------------------- |
-| previous_event_hash    | `EventId` 	  | Hash of the previous `Event`|
-| action     			 | `EventAction`  | `Event`'s action 			|
-| timestamp     		 | u64  		  | `Event`'s timestamp 		|
+| previous_event_hash    | `EventId`      | Hash of the previous `Event`|
+| action                 | `EventAction`  | `Event`'s action            |
+| timestamp              | u64            | `Event`'s timestamp         |
 
 ## EventNode
 
-| Description    | Data Type      		  | Comments                    			 			  |
+| Description    | Data Type              | Comments                                              |
 |--------------- | ---------------------- | ----------------------------------------------------- |
-| parent    	 | Option<`EventId`> 	  | Only current root has this set to None   			  |
-| event     	 | `Event`  			  | The `Event` itself 					       			  |
-| children     	 | Vec<`EventId`>  	      | The `Event`s which has parent as this `Event` hash    |
+| parent         | Option<`EventId`>      | Only current root has this set to None                |
+| event          | `Event`                | The `Event` itself                                    |
+| children       | Vec<`EventId`>         | The `Event`s which has parent as this `Event` hash    |
 
-## Model 
+## Model
 
-The `Model` consist of chains(`EventNodes`) structured as a tree, each chain has Event-based
-list. To maintain strict order in chain, Each `Event` dependent on the hash of the previous `Event`. 
-All the chains share a root `Event` to preserve the tree structure. 
+The `Model` consists of chains (`EventNodes`) structured as a tree; whereby, each chain has an `Event`-based
+list. To maintain a strict order of chains, each `Event` depends on the hash of the previous `Event`.
+All of the chains share a root `Event` to preserve the tree structure.
 
-| Description   | Data Type      		  		   | Comments                      |
+| Description   | Data Type                        | Comments                      |
 |-------------- | -------------------------------- | ----------------------------- |
-| current_root  | `EventId` 	  		  		   | The root `Event` for the tree |
-| orphans       | HashMap<`EventId`, `Event`>  	   | Recently added `Event`s 	   |
-| event_map     | HashMap<`EventId`, `EventNode`>  | The actual tree  		 	   |
-| events_queue  | `EventsQueue`					   | Communication channel 
+| current_root  | `EventId`                        | The root `Event` for the tree |
+| orphans       | HashMap<`EventId`, `Event`>      | Recently added `Event`s       |
+| event_map     | HashMap<`EventId`, `EventNode`>  | The actual tree               |
+| events_queue  | `EventsQueue`                    | Communication channel         |
 
-## View 
+## View
 
-The `View` check the `Model` for new `Event`s, then dispatch these `Event`s to the clients. 
+The `View` checks the `Model` for new `Event`s and then dispatches these `Event`s to the clients.
 
 `Event`s are sorted according to the timestamp attached to each `Event`.
 
-| Description   | Data Type      	   		    | Comments               |
+| Description   | Data Type                     | Comments               |
 |-------------- | ----------------------------- | ---------------------- |
-| seen  		| HashMap<`EventId`, `Event`>   | A list of `Event`s 	 |
+| seen          | HashMap<`EventId`, `Event`>   | A list of `Event`s     |
 
-## EventsQueue 
+## EventsQueue
 
 The `EventsQueue` used to transport the event from `Model` to `View`.
 
-The `Model` fill The `EventsQueue` with the new `Event`, while the `View` keep
-fetching `Event`s from queue continuously.
+The `Model` fills the `EventsQueue` with the new `Event`, while the `View` continuously
+fetches `Event`s from queue.
 
-# Architecture 
+# Architecture
 
-Tau using Model–view software architecture. All the operations, main data structures, 
-and handling messages from network protocol, happen in the `Model` side. 
-While keeping the `View` independent of the `Model` and focusing on getting update 
-from it continuously.
+Tau uses Model–view software architecture. All of the operations, main data structures,
+and message handling from the network protocol happen on the `Model` side.
+Further, this keeps the `View` independent of the `Model`
+and allows the `View` to focus on receiving continuous updates from it.
 
-## Add new Event
+## Add new `Event`
 
-Once receiving new `Event` from the network protocol, the `Event` will be add to the
-orphans list. 
+Upon receiving a new `Event` from the network protocol, the `Event` will be added to the
+orphans list.
 
-After the ancestor for the new orphan gets found, The orphan `Event` will be add to the chain
+After the ancestor of the new orphan is found, the orphan `Event` will be added to the chain
 according to its ancestor.
 
-For example, in the <em> Example1 </em> below, An `Event` add to the first chain if
-its previous hash is Event-A1
+For example: in [Example1](#example1) below, an `Event` is added to the first chain if
+its previous hash is Event-A1.
 
-## Remove old leaves 
+## Remove old leaves
 
-Remove leaves which are too far from the head leaf(the leaf in the longest chain).
+Remove leaves which are too far from the head leaf (the leaf in the longest chain).
 
-The depth difference from the common ancestor between a leaf to be removed and a head leaf 
-must be greater than `MAX_DEPTH`. 
+The depth difference from the common ancestor between a leaf to be removed and a head leaf
+must be greater than `MAX_DEPTH`.
 
-## Update the root 
+## Update the root
 
 Finding the highest common ancestor for the leaves and assign it as the root
 for the tree.
 
-The highest common ancestor must have height greater than `MAX_HEIGHT`.
+The highest common ancestor must have a height greater than `MAX_HEIGHT`.
+
+## Example1
 
 ![data structure](../../assets/mv_event.png)
-
-Example1
-
-
-
-

--- a/doc/src/misc/hashchain/hashchain.md
+++ b/doc/src/misc/hashchain/hashchain.md
@@ -19,7 +19,7 @@ enum EventAction { ... };
 ## Event
 
 | Description            | Data Type      | Comments                    |
-|----------------------- | -------------- | --------------------------- |
+| ---------------------- | -------------- | --------------------------- |
 | previous_event_hash    | `EventId`      | Hash of the previous `Event`|
 | action                 | `EventAction`  | `Event`'s action            |
 | timestamp              | u64            | `Event`'s timestamp         |
@@ -27,19 +27,21 @@ enum EventAction { ... };
 ## EventNode
 
 | Description    | Data Type              | Comments                                              |
-|--------------- | ---------------------- | ----------------------------------------------------- |
+| -------------- | ---------------------- | ----------------------------------------------------- |
 | parent         | Option<`EventId`>      | Only current root has this set to None                |
 | event          | `Event`                | The `Event` itself                                    |
 | children       | Vec<`EventId`>         | The `Event`s which has parent as this `Event` hash    |
 
 ## Model
 
-The `Model` consists of chains (`EventNodes`) structured as a tree; whereby, each chain has an `Event`-based
-list. To maintain a strict order of chains, each `Event` depends on the hash of the previous `Event`.
-All of the chains share a root `Event` to preserve the tree structure.
+The `Model` consists of chains (`EventNodes`) structured as a tree;
+whereby, each chain has an `Event`-based list. To maintain a strict
+order of chains, each `Event` depends on the hash of the previous
+`Event`. All of the chains share a root `Event` to preserve the tree
+structure.
 
 | Description   | Data Type                        | Comments                      |
-|-------------- | -------------------------------- | ----------------------------- |
+| ------------- | -------------------------------- | ----------------------------- |
 | current_root  | `EventId`                        | The root `Event` for the tree |
 | orphans       | HashMap<`EventId`, `Event`>      | Recently added `Event`s       |
 | event_map     | HashMap<`EventId`, `EventNode`>  | The actual tree               |
@@ -47,52 +49,57 @@ All of the chains share a root `Event` to preserve the tree structure.
 
 ## View
 
-The `View` checks the `Model` for new `Event`s and then dispatches these `Event`s to the clients.
+The `View` checks the `Model` for new `Event`s and then dispatches
+these `Event`s to the clients.
 
-`Event`s are sorted according to the timestamp attached to each `Event`.
+`Event`s are sorted according to the timestamp attached to each
+`Event`.
 
 | Description   | Data Type                     | Comments               |
-|-------------- | ----------------------------- | ---------------------- |
+| ------------- | ----------------------------- | ---------------------- |
 | seen          | HashMap<`EventId`, `Event`>   | A list of `Event`s     |
 
 ## EventsQueue
 
 The `EventsQueue` used to transport the event from `Model` to `View`.
 
-The `Model` fills the `EventsQueue` with the new `Event`, while the `View` continuously
-fetches `Event`s from queue.
+The `Model` fills the `EventsQueue` with the new `Event`, while the
+`View` continuously fetches `Event`s from queue.
 
 # Architecture
 
-Tau uses Model–view software architecture. All of the operations, main data structures,
-and message handling from the network protocol happen on the `Model` side.
-Further, this keeps the `View` independent of the `Model`
-and allows the `View` to focus on receiving continuous updates from it.
+Tau uses Model–view software architecture. All of the operations, main
+data structures, and message handling from the network protocol happen
+on the `Model` side. Further, this keeps the `View` independent of the
+`Model` and allows the `View` to focus on receiving continuous updates
+from it.
 
 ## Add new `Event`
 
-Upon receiving a new `Event` from the network protocol, the `Event` will be added to the
-orphans list.
+Upon receiving a new `Event` from the network protocol, the `Event`
+will be added to the orphans list.
 
-After the ancestor of the new orphan is found, the orphan `Event` will be added to the chain
-according to its ancestor.
+After the ancestor of the new orphan is found, the orphan `Event` will
+be added to the chain according to its ancestor.
 
-For example: in [Example1](#example1) below, an `Event` is added to the first chain if
-its previous hash is Event-A1.
+For example: in [Example1](#example1) below, an `Event` is added to the
+first chain if its previous hash is Event-A1.
 
 ## Remove old leaves
 
-Remove leaves which are too far from the head leaf (the leaf in the longest chain).
+Remove leaves which are too far from the head leaf (the leaf in the
+longest chain).
 
-The depth difference from the common ancestor between a leaf to be removed and a head leaf
-must be greater than `MAX_DEPTH`.
+The depth difference from the common ancestor between a leaf to be
+removed and a head leaf must be greater than `MAX_DEPTH`.
 
 ## Update the root
 
-Finding the highest common ancestor for the leaves and assign it as the root
-for the tree.
+Finding the highest common ancestor for the leaves and assign it as the
+root for the tree.
 
-The highest common ancestor must have a height greater than `MAX_HEIGHT`.
+The highest common ancestor must have a height greater than
+`MAX_HEIGHT`.
 
 ## Example1
 

--- a/doc/src/misc/hashchain/network_protocol.md
+++ b/doc/src/misc/hashchain/network_protocol.md
@@ -19,7 +19,7 @@ Inventory vectors notify other nodes about objects they have or data which is be
 
 | Description   | Data Type            | Comments                   |
 |-------------- | -------------------- | -------------------------- |
-| invs          | Vec`<[u8; 32]>`      | Inventory items            |
+| invs          | `Vec<[u8; 32]>`      | Inventory items            |
 
 ### Receiving an `Inv` message
 

--- a/doc/src/misc/hashchain/network_protocol.md
+++ b/doc/src/misc/hashchain/network_protocol.md
@@ -1,59 +1,60 @@
 # Network Protocol
 
-The protocol check that `Event`s have properly broadcasted through the
-network before adding `Event`s to the `Model`. 
+The protocol checks that `Event`s properly broadcast through the
+network before adding `Event`s to the `Model`.
 
-The read_confirms inside each `Event` indicate how many times the `Event` has 
+The read_confirms inside each `Event` indicate how many times the `Event` has
 been read from other nodes in the network.
 
-The protocol classify the Events by their state:
+The protocol classifies the `Event`s by their state:
 
-	Unread: read_confirms < `MAX_CONFIMRS` 
-	Read: 	read_confirms >= `MAX_CONFIMRS` 
+```text
+Unread: read_confirms < MAX_CONFIRMS
+Read:	read_confirms >= MAX_CONFIRMS
+```
 
 ## Inv
 
-Inventory vectors are used for notifying other nodes about objects they have or data which is being requested.
+Inventory vectors notify other nodes about objects they have or data which is being requested.
 
-| Description   | Data Type      	   | Comments           		|
+| Description   | Data Type            | Comments                   |
 |-------------- | -------------------- | -------------------------- |
-| invs	  	  	| `Vec<[u8; 32]>`      | Inventory items    		|
+| invs          | `Vec<[u8; 32]>`      | Inventory items            |
 
 ### Receiving an `Inv` message
 
-Allows a node to advertise its knowledge of one or more objects. It can be received unsolicited,
-or in reply to `getevents`. 
+Allows a node to advertise its knowledge of one or more objects. It can be received unsolicited
+or in reply to `getevents`.
 
 An `Inv` message is a confirmation from a node in the network that the `Event`
 has been read.
 
-Confirmation for an `Event` not exist in the `UnreadEvents` list, 
-The protocol send a `GetData` message to request the missing `Event`.
+Confirmation for an `Event` does not exist in the `UnreadEvents` list.
+Instead, the protocol sends a `GetData` message to request the missing `Event`.
 
-The protocol update the `Event` in the `UnreadEvents` list by increasing the
+The protocol updates the `Event` in the `UnreadEvents` list by increasing the
 read_confirms by one.
 
-The state for updated `Event` change to read when the read_confirms exceed
-`MAX_CONFIMRS`, Then the `Event remove from the `UnreadEvents` list and add to the `Model`. 
+The updated `Event` state changes to read when the read_confirms exceed
+`MAX_CONFIRMS`. Then, the `UnreadEvents` list removes the `Event` and adds it to the `Model`.
 
-The protocol rebroadcast the received `Inv` to the network.
+The protocol rebroadcasts the received `Inv` to the network.
 
 ### Sending an `Inv` message
 
-On receiving an `Event` with unread status from the network, The protocol send back 
+Upon receiving an `Event` with unread status from the network, the protocol sends back
 an `Inv` message to confirm that the `Event` has been read.
 
 ## GetData
 
-| Description   | Data Type      	   | Comments              		|
+| Description   | Data Type            | Comments                   |
 |-------------- | -------------------- | -------------------------- |
-| events	  	| Vec<`EventId`> 	   | A list of `EventId`   		|
+| events        | Vec<`EventId`>       | A list of `EventId`s       |
 
 ### Receiving a `GetData` message
 
-The protocol search in both `Model` and `UnreadEvents` for requested `Event`s
+The protocol searches in both `Model` and `UnreadEvents` for the requested `Event`s
 in `GetData` message.
-
 
 ## UnreadEvents
 
@@ -61,68 +62,66 @@ in `GetData` message.
 |-------------|---------------------------- | -------------------------------------------------------------------------------------|
 | Messages    | HashMap<`EventId`, `Event`> | Hold all the `Event`s that have broadcasted to other nodes but haven't confirmed yet |
 
-### Add new `Event` to `UnreadEvents` 
+### Add new `Event` to `UnreadEvents`
 
 To add an `Event` to `UnreadEvents`, the protocol first must check the validity of
-`Event`. 
+`Event`.
 
-The `Event` is not valid in the network if it's too far in the future from now,
-or too far in the past from now.
+The `Event` is not valid in the network if it's either too far in the future or in the past.
 
 ### Updating `UnreadEvents` list
 
-The protocol continually broadcast unread `Event` to the network 
-after a certain period of time(`SEND_UNREAD_EVENTS_INTERVAL`), 
-Until the state of `Event` updated to read.
+The protocol continuously broadcasts unread `Event`s to the network,
+after a certain period of time (`SEND_UNREAD_EVENTS_INTERVAL`),
+until the state of `Event` updates to read.
 
-## SyncEvent 
+## SyncEvent
 
-| Description | Data Type    	| Comments					 	|
+| Description | Data Type       | Comments                      |
 |-------------|---------------- |------------------------------ |
-| Leaves	  | Vec<`EventId`> 	| hash of `Event`s   			|
+| Leaves      | Vec<`EventId`>  | Hash of `Event`s              |
 
 ### Synchronization
 
-To achieve complete synchronization between nodes, the protocol send a
+To achieve complete synchronization between nodes, the protocol sends a
 `SyncEvent` message every 2 seconds to other nodes in the network.
 
 The `SyncEvent` contains the hashes of `Event`s set in the leaves of `Model`'s tree.
 
-On receiving `SyncEvent` message, The leaves in `SyncEvent` should match the 
-leaves in the `Model`'s tree, Otherwise the protocol send `Event`s which are the childern of
-`Event`s in `SyncEvent` 
+On receiving `SyncEvent` message, the leaves in `SyncEvent` should match the
+leaves in the `Model`'s tree; otherwise, the protocol sends `Event`s which are the children of
+`Event`s in `SyncEvent`.
 
-## Seen<ObjectId>
+## Seen
 
-This used to prevent receiving duplicate Objects.
-The list will contains only 2^16 ids.
+This prevents receiving duplicate objects.
+The list contains only 2^16 ids.
 
-| Description | Data Type      | Comments			  		   |
+| Description | Data Type      | Comments                      |
 |-------------|--------------- |------------------------------ |
-| Ids		  | Vec<ObjectId>  | Contains objects ids    	   |
-
+| Ids         | Vec            | Contains objects ids          |
 
 ## Receiving a new `Event`
 
-The new received `Event` with unread status add to the `UnreadEvents` buffer after
-increasing the read_confirms by one. 
+The new received `Event` with unread status is added to the `UnreadEvents` buffer after
+increasing the read_confirms by one.
 
-The `Event` with read status add to the `Model`.
+The `Event` with read status is added to the `Model`.
 
-The protocol broadcast the received `Event` to the network again, to ensure every nodes
+The protocol broadcasts the received `Event` to the network, again. This ensures all nodes
 in the network get the Event.
 
 ## Sending an `Event`
 
 A new created `Event` has unread status with read_confirms equal to 0.
 
-The protocol broadcast the `Event` to the network after adding it to the
+The protocol broadcasts the `Event` to the network after adding it to the
 `UnreadEvents`.
 
-## Add new `Event` to `Model` 
+## Add new `Event` to `Model`
 
-For the `Event` to be successfully add to the `Model`, the protocol check if
-the previous `Event`'s hash inside the `Event` is exist in the `Model`.
+For the `Event` to be successfully added to the `Model`, the protocol checks if
+the previous `Event`'s hash inside the `Event` exists in the `Model`.
 
-In case the check for previous `Event` failed The protocol 
-send a `GetData` message requesting the previous `Event`.
+In case the check for previous `Event` failed, the protocol
+sends a `GetData` message requesting the previous `Event`.

--- a/doc/src/misc/hashchain/network_protocol.md
+++ b/doc/src/misc/hashchain/network_protocol.md
@@ -19,7 +19,7 @@ Inventory vectors notify other nodes about objects they have or data which is be
 
 | Description   | Data Type            | Comments                   |
 |-------------- | -------------------- | -------------------------- |
-| invs          | `Vec<[u8; 32]>`      | Inventory items            |
+| invs          | Vec`<[u8; 32]>`      | Inventory items            |
 
 ### Receiving an `Inv` message
 
@@ -97,9 +97,9 @@ leaves in the `Model`'s tree; otherwise, the protocol sends `Event`s which are t
 This prevents receiving duplicate objects.
 The list contains only 2^16 ids.
 
-| Description | Data Type      | Comments                      |
-|-------------|--------------- |------------------------------ |
-| Ids         | Vec            | Contains objects ids          |
+| Description | Data Type       | Comments                      |
+| ----------- | --------------- |------------------------------ |
+| Ids         | Vec<`ObjectId`> | Contains objects ids          |
 
 ## Receiving a new `Event`
 

--- a/doc/src/misc/hashchain/network_protocol.md
+++ b/doc/src/misc/hashchain/network_protocol.md
@@ -19,7 +19,7 @@ Inventory vectors notify other nodes about objects they have or data
 which is being requested.
 
 | Description   | Data Type            | Comments                   |
-|-------------- | -------------------- | -------------------------- |
+| ------------- | -------------------- | -------------------------- |
 | invs          | `Vec<[u8; 32]>`      | Inventory items            |
 
 ### Receiving an `Inv` message
@@ -52,7 +52,7 @@ been read.
 ## GetData
 
 | Description   | Data Type            | Comments                   |
-|-------------- | -------------------- | -------------------------- |
+| ------------- | -------------------- | -------------------------- |
 | events        | Vec<`EventId`>       | A list of `EventId`s       |
 
 ### Receiving a `GetData` message
@@ -63,7 +63,7 @@ requested `Event`s in `GetData` message.
 ## UnreadEvents
 
 | Description | Data Type                   | Comments                                                                             |
-|-------------|---------------------------- | -------------------------------------------------------------------------------------|
+| ------------| --------------------------- | ------------------------------------------------------------------------------------ |
 | Messages    | HashMap<`EventId`, `Event`> | Hold all the `Event`s that have broadcasted to other nodes but haven't confirmed yet |
 
 ### Add new `Event` to `UnreadEvents`
@@ -83,7 +83,7 @@ until the state of `Event` updates to read.
 ## SyncEvent
 
 | Description | Data Type       | Comments                      |
-|-------------|---------------- |------------------------------ |
+| ------------| --------------- | ----------------------------- |
 | Leaves      | Vec<`EventId`>  | Hash of `Event`s              |
 
 ### Synchronization
@@ -104,7 +104,7 @@ This prevents receiving duplicate objects.
 The list contains only 2^16 ids.
 
 | Description | Data Type       | Comments                      |
-| ----------- | --------------- |------------------------------ |
+| ----------- | --------------- | ----------------------------- |
 | Ids         | Vec<`ObjectId`> | Contains objects ids          |
 
 ## Receiving a new `Event`

--- a/doc/src/misc/hashchain/network_protocol.md
+++ b/doc/src/misc/hashchain/network_protocol.md
@@ -123,5 +123,5 @@ The protocol broadcasts the `Event` to the network after adding it to the
 For the `Event` to be successfully added to the `Model`, the protocol checks if
 the previous `Event`'s hash inside the `Event` exists in the `Model`.
 
-In case the check for previous `Event` failed, the protocol
+In case the previous `Event` check fails, the protocol
 sends a `GetData` message requesting the previous `Event`.

--- a/doc/src/misc/hashchain/network_protocol.md
+++ b/doc/src/misc/hashchain/network_protocol.md
@@ -3,8 +3,8 @@
 The protocol checks that `Event`s properly broadcast through the
 network before adding `Event`s to the `Model`.
 
-The read_confirms inside each `Event` indicate how many times the `Event` has
-been read from other nodes in the network.
+The read_confirms inside each `Event` indicate how many times the
+`Event` has been read from other nodes in the network.
 
 The protocol classifies the `Event`s by their state:
 
@@ -15,7 +15,8 @@ Read:	read_confirms >= MAX_CONFIRMS
 
 ## Inv
 
-Inventory vectors notify other nodes about objects they have or data which is being requested.
+Inventory vectors notify other nodes about objects they have or data
+which is being requested.
 
 | Description   | Data Type            | Comments                   |
 |-------------- | -------------------- | -------------------------- |
@@ -23,27 +24,30 @@ Inventory vectors notify other nodes about objects they have or data which is be
 
 ### Receiving an `Inv` message
 
-Allows a node to advertise its knowledge of one or more objects. It can be received unsolicited
-or in reply to `getevents`.
+Allows a node to advertise its knowledge of one or more objects. It can
+be received unsolicited or in reply to `getevents`.
 
-An `Inv` message is a confirmation from a node in the network that the `Event`
-has been read.
+An `Inv` message is a confirmation from a node in the network that the
+`Event` has been read.
 
 Confirmation for an `Event` does not exist in the `UnreadEvents` list.
-Instead, the protocol sends a `GetData` message to request the missing `Event`.
+Instead, the protocol sends a `GetData` message to request the missing
+`Event`.
 
-The protocol updates the `Event` in the `UnreadEvents` list by increasing the
-read_confirms by one.
+The protocol updates the `Event` in the `UnreadEvents` list by
+increasing the read_confirms by one.
 
 The updated `Event` state changes to read when the read_confirms exceed
-`MAX_CONFIRMS`. Then, the `UnreadEvents` list removes the `Event` and adds it to the `Model`.
+`MAX_CONFIRMS`. Then, the `UnreadEvents` list removes the `Event` and
+adds it to the `Model`.
 
 The protocol rebroadcasts the received `Inv` to the network.
 
 ### Sending an `Inv` message
 
-Upon receiving an `Event` with unread status from the network, the protocol sends back
-an `Inv` message to confirm that the `Event` has been read.
+Upon receiving an `Event` with unread status from the network, the
+protocol sends back an `Inv` message to confirm that the `Event` has
+been read.
 
 ## GetData
 
@@ -53,8 +57,8 @@ an `Inv` message to confirm that the `Event` has been read.
 
 ### Receiving a `GetData` message
 
-The protocol searches in both `Model` and `UnreadEvents` for the requested `Event`s
-in `GetData` message.
+The protocol searches in both `Model` and `UnreadEvents` for the
+requested `Event`s in `GetData` message.
 
 ## UnreadEvents
 
@@ -64,10 +68,11 @@ in `GetData` message.
 
 ### Add new `Event` to `UnreadEvents`
 
-To add an `Event` to `UnreadEvents`, the protocol first must check the validity of
-`Event`.
+To add an `Event` to `UnreadEvents`, the protocol first must check the
+ validity of `Event`.
 
-The `Event` is not valid in the network if it's either too far in the future or in the past.
+The `Event` is not valid in the network if it's either too far in the
+future or in the past.
 
 ### Updating `UnreadEvents` list
 
@@ -86,11 +91,12 @@ until the state of `Event` updates to read.
 To achieve complete synchronization between nodes, the protocol sends a
 `SyncEvent` message every 2 seconds to other nodes in the network.
 
-The `SyncEvent` contains the hashes of `Event`s set in the leaves of `Model`'s tree.
+The `SyncEvent` contains the hashes of `Event`s set in the leaves of
+`Model`'s tree.
 
-On receiving `SyncEvent` message, the leaves in `SyncEvent` should match the
-leaves in the `Model`'s tree; otherwise, the protocol sends `Event`s which are the children of
-`Event`s in `SyncEvent`.
+On receiving `SyncEvent` message, the leaves in `SyncEvent` should
+match the leaves in the `Model`'s tree; otherwise, the protocol sends
+`Event`s which are the children of `Event`s in `SyncEvent`.
 
 ## Seen
 
@@ -103,25 +109,26 @@ The list contains only 2^16 ids.
 
 ## Receiving a new `Event`
 
-The new received `Event` with unread status is added to the `UnreadEvents` buffer after
-increasing the read_confirms by one.
+The new received `Event` with unread status is added to the
+`UnreadEvents` buffer after increasing the read_confirms by one.
 
 The `Event` with read status is added to the `Model`.
 
-The protocol broadcasts the received `Event` to the network, again. This ensures all nodes
-in the network get the Event.
+The protocol broadcasts the received `Event` to the network, again.
+This ensures all nodes in the network get the Event.
 
 ## Sending an `Event`
 
 A new created `Event` has unread status with read_confirms equal to 0.
 
-The protocol broadcasts the `Event` to the network after adding it to the
-`UnreadEvents`.
+The protocol broadcasts the `Event` to the network after adding it to
+the `UnreadEvents`.
 
 ## Add new `Event` to `Model`
 
-For the `Event` to be successfully added to the `Model`, the protocol checks if
-the previous `Event`'s hash inside the `Event` exists in the `Model`.
+For the `Event` to be successfully added to the `Model`, the protocol
+checks if the previous `Event`'s hash inside the `Event` exists in the
+`Model`.
 
 In case the previous `Event` check fails, the protocol
 sends a `GetData` message requesting the previous `Event`.


### PR DESCRIPTION
This PR proposes to improve the markdown syntax and readability of the hashchain/hashchain.md and hashchain/network_protocol.md documentation. Some of the proposed changes include:
- Fix typos.
- Remove trailing spaces.
- Add rust code blocks to enable syntax highlighting in hashchain.md.
- Improve grammar.
  - A few of the third-person present tense verbs require the _-s_ suffix. For example:
     - "The `View` check the..."
is changed to:
     - "The `View` checks the..."
  - Punctuation/capitalization.
- Wrap lines at 72 columns (a few of the tables, however, still go over).
- Add link to .png example.