### PR TITLE
docker-remove-old-bins-and-remove-apt-cache

### DIFF
--- a/contrib/docker/Dockerfile.debian
+++ b/contrib/docker/Dockerfile.debian
@@ -1,5 +1,5 @@
 
-# Use: docker build . -t darkfi:debian -f ./contrib/docker/Dockerfile.debian
+# Use: docker build . --pull --network=host -t darkfi:debian -f ./contrib/docker/Dockerfile.debian
 #   optionally with: --build-arg BUILD_OS_VER=slim-buster --build-arg RUN_OS_VER=buster-slim --build-arg RUST_VER=1.65
 #   rust nightly with: BUILD_OS_VER=bullseye-slim RUN_OS_VER=bullseye-slim RUST_VER=nightly REPOSITORY=rustlang/rust
 
@@ -20,6 +20,8 @@ COPY . /opt/darkfi
 
 WORKDIR /opt/darkfi
 
+RUN rustup target add wasm32-unknown-unknown
+
 RUN make clean
 
 RUN rm -rf ./target/*
@@ -30,10 +32,10 @@ RUN bash -c 'make -j test &&  make -j all'
 FROM debian:${RUN_OS_VER}
 
 RUN apt-get -y update && apt-get install -y openssl fonts-lato \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/darkfi
 
-COPY --from=builder /opt/darkfi/drk /opt/darkfi/darkfid /opt/darkfi/tau \
-  /opt/darkfi/taud /opt/darkfi/ircd /opt/darkfi/dnetview /opt/darkfi/faucetd \
-  /opt/darkfi/darkwikid /opt/darkfi/darkwiki /opt/darkfi/zkas /opt/darkfi/vanityaddr  ./
+COPY --from=builder /opt/darkfi/drk /opt/darkfi/darkfid  \
+   /opt/darkfi/ircd /opt/darkfi/dnetview /opt/darkfi/faucetd \
+   /opt/darkfi/zkas /opt/darkfi/vanityaddr  ./

--- a/contrib/docker/Dockerfile.fedora
+++ b/contrib/docker/Dockerfile.fedora
@@ -14,8 +14,6 @@ RUN dnf -y install gcc gcc-c++ kernel-headers cmake jq wget \
   openssl-devel findutils fontconfig-devel \
   lato-fonts
 
-## TODO ?? ?? cargo rustc rust-libudev-devel rust-freetype-rs-devel rust-expat-sys-devel
-
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain "${RUST_VER}"
 
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -40,10 +38,12 @@ RUN bash -c 'make -j test &&  make -j all'
 # 3. stage
 FROM ${OS_VER}
 
-RUN dnf -y install openssl lato-fonts
+RUN dnf -y install openssl lato-fonts \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
 
 WORKDIR /opt/darkfi
 
-COPY --from=builder /opt/darkfi/drk /opt/darkfi/darkfid /opt/darkfi/tau \
-  /opt/darkfi/taud /opt/darkfi/ircd /opt/darkfi/dnetview /opt/darkfi/faucetd \
-  /opt/darkfi/darkwikid /opt/darkfi/darkwiki /opt/darkfi/zkas /opt/darkfi/vanityaddr  ./
+COPY --from=builder /opt/darkfi/drk /opt/darkfi/darkfid  \
+   /opt/darkfi/ircd /opt/darkfi/dnetview /opt/darkfi/faucetd \
+   /opt/darkfi/zkas /opt/darkfi/vanityaddr  ./

--- a/contrib/docker/Dockerfile.ubuntu
+++ b/contrib/docker/Dockerfile.ubuntu
@@ -41,11 +41,11 @@ RUN bash -c 'make -j test &&  make -j all'
 FROM ${REPOSITORY}:${RUN_OS_VER}
 
 RUN apt-get -y update && apt-get install -y openssl fonts-lato \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/darkfi
 
-COPY --from=builder /opt/darkfi/drk /opt/darkfi/darkfid /opt/darkfi/tau \
-  /opt/darkfi/taud /opt/darkfi/ircd /opt/darkfi/dnetview /opt/darkfi/faucetd \
-  /opt/darkfi/darkwikid /opt/darkfi/darkwiki /opt/darkfi/zkas /opt/darkfi/vanityaddr  ./
+COPY --from=builder /opt/darkfi/drk /opt/darkfi/darkfid  \
+   /opt/darkfi/ircd /opt/darkfi/dnetview /opt/darkfi/faucetd \
+   /opt/darkfi/zkas /opt/darkfi/vanityaddr  ./
 


### PR DESCRIPTION
docker build passed for {debianBuster,fedora37,ubuntu22}_rust1.65