### PR TITLE
fix testnet page broken links

### DIFF
--- a/doc/src/testnet/testnet.md
+++ b/doc/src/testnet/testnet.md
@@ -6,9 +6,9 @@ testnet. In it, we cover basic setup of the `darkfid` node daemon,
 initializing a wallet, and interacting with the _money contract_,
 which provides infrastructure for payments and atomic swaps.
 
-1. [Compile and run a node](testnet/node.md)
-2. [Airdrop yourself funds](testnet/airdrop.md)
-3. [Make some payments](testnet/payment.md)
-4. [Do some atomic swaps](testnet/atomic-swap.md)
-5. [Create an on-chain DAO](testnet/dao.md)
+1. [Compile and run a node](node.md)
+2. [Airdrop yourself funds](airdrop.md)
+3. [Make some payments](payment.md)
+4. [Do some atomic swaps](atomic-swap.md)
+5. [Create an on-chain DAO](dao.md)
 


### PR DESCRIPTION
hi, the links in doc/src/testnet/testnet.md are broken,i think they should be (page.md) instead of (testnet/page.md), because the testnet.md page is under testnet directory
![image](https://user-images.githubusercontent.com/106676833/220054072-e7188971-16d0-48bc-bace-3ebf7700edb0.png)
