### PR TITLE
bin/darkfid/src/main.rs:  fix path

### DIFF
--- a/bin/darkfid/src/main.rs
+++ b/bin/darkfid/src/main.rs
@@ -17,6 +17,7 @@
  */
 
 use std::str::FromStr;
+use std::path::Path;
 
 use async_std::sync::{Arc, Mutex};
 use async_trait::async_trait;
@@ -300,8 +301,7 @@ async fn realmain(args: Args, ex: Arc<smol::Executor<'_>>) -> Result<()> {
     let wallet = init_wallet(&args.wallet_path, &args.wallet_pass).await?;
 
     // Initialize or open sled database
-    // TODO: Use proper OsPath here, not {}/{}
-    let db_path = format!("{}/{}", expand_path(&args.database)?.to_str().unwrap(), args.chain);
+    let db_path = Path::new(expand_path(&args.database)?.to_str().unwrap()).join(args.chain.clone());
     let sled_db = sled::open(&db_path)?;
 
     // Initialize validator state


### PR DESCRIPTION
Updates line 304:
``` rust
   let db_path = format!("{}/{}", expand_path(&args.database)?.to_str().unwrap(), args.chain);
```
to:
``` rust
    let db_path = Path::new(expand_path(&args.database)?.to_str().unwrap()).join(args.chain.clone());
```