### PR TITLE
Faucet path fix

### DIFF
--- a/bin/faucetd/src/main.rs
+++ b/bin/faucetd/src/main.rs
@@ -234,11 +234,11 @@ impl Faucetd {
         let db_handle =
             blockchain.contracts.lookup(&blockchain.sled_db, &cid, SMART_CONTRACT_ZKAS_DB_NAME)?;
 
-        let Some(mint_zkbin) = db_handle.get(&serialize(&MONEY_CONTRACT_ZKAS_MINT_NS_V1))? else {
+        let Some(mint_zkbin) = db_handle.get(serialize(&MONEY_CONTRACT_ZKAS_MINT_NS_V1))? else {
             error!("{} zkas bincode not found in sled database", MONEY_CONTRACT_ZKAS_MINT_NS_V1);
             return Err(Error::ZkasBincodeNotFound);
         };
-        let Some(burn_zkbin) = db_handle.get(&serialize(&MONEY_CONTRACT_ZKAS_BURN_NS_V1))? else {
+        let Some(burn_zkbin) = db_handle.get(serialize(&MONEY_CONTRACT_ZKAS_BURN_NS_V1))? else {
             error!("{} zkas bincode not found in sled database", MONEY_CONTRACT_ZKAS_BURN_NS_V1);
             return Err(Error::ZkasBincodeNotFound);
         };

--- a/bin/faucetd/src/main.rs
+++ b/bin/faucetd/src/main.rs
@@ -552,7 +552,6 @@ async fn realmain(args: Args, ex: Arc<smol::Executor<'_>>) -> Result<()> {
     let wallet = init_wallet(&args.wallet_path, &args.wallet_pass).await?;
 
     // Initialize or open sled database
-    // TODO: Use proper OsPath here, not {}/{}
     let db_path =
         Path::new(expand_path(&args.database)?.to_str().unwrap()).join(args.chain.clone());
     let sled_db = sled::open(&db_path)?;

--- a/bin/faucetd/src/main.rs
+++ b/bin/faucetd/src/main.rs
@@ -16,7 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use async_std::{
     stream::StreamExt,
@@ -549,7 +553,8 @@ async fn realmain(args: Args, ex: Arc<smol::Executor<'_>>) -> Result<()> {
 
     // Initialize or open sled database
     // TODO: Use proper OsPath here, not {}/{}
-    let db_path = format!("{}/{}", expand_path(&args.database)?.to_str().unwrap(), args.chain);
+    let db_path =
+        Path::new(expand_path(&args.database)?.to_str().unwrap()).join(args.chain.clone());
     let sled_db = sled::open(&db_path)?;
 
     // Initialize validator state


### PR DESCRIPTION
Updates db_path to use std::path, as follows:
```rust
   let db_path = format!("{}/{}", expand_path(&args.database)?.to_str().unwrap(), args.chain);
```
to:
```rust
    let db_path = Path::new(expand_path(&args.database)?.to_str().unwrap()).join(args.chain.clone());
```