### PR TITLE
Fix x3dh sig

### DIFF
--- a/script/research/x3dh/src/main.rs
+++ b/script/research/x3dh/src/main.rs
@@ -456,7 +456,8 @@ fn main() {
 
     // Bob's prekey signature `Sig(IK_b, Encode(SPK_B))`
     let nonce = [0_u8; 64];
-    let bob_spk_sig = bob_ik_secret.xeddsa_sign(&bob_spk_public.to_bytes(), &nonce);
+    //let bob_spk_signature = bob_ik_secret.xeddsa_sign(&bob_spk_public.to_bytes(), &nonce);
+    let bob_spk_signature = bob_ik_secret.xeddsa_sign(&bob_spk_public.to_bytes(), &nonce);
 
     // A set of Bob's one-time prekeys `(OPK_B1, OPK_B2, OPK_B3, ...)`
     let mut bob_opk_secrets =
@@ -468,7 +469,7 @@ fn main() {
 
     let bob_keyset = Keyset {
         signed_prekey: bob_spk_public,
-        prekey_signature: bob_spk_sig,
+        prekey_signature: bob_spk_signature,
         onetime_prekeys: bob_opk_publics.clone(),
     };
 
@@ -485,11 +486,6 @@ fn main() {
 
     // Alice verifies the prekey signature and aborts the protocol if
     // verification fails.
-
-    println!("\n{:?}", bob_keyset.signed_prekey.to_bytes().clone());
-    println!("{:?}", bob_keyset.signed_prekey.to_bytes().clone().len());
-    println!("\n{:?}", bob_keyset.prekey_signature.clone());
-    println!("{:?}", bob_keyset.prekey_signature.clone().len());
 
     assert!(bob_keyset
         .identity_key

--- a/script/research/x3dh/src/main.rs
+++ b/script/research/x3dh/src/main.rs
@@ -450,14 +450,18 @@ fn main() {
     // at some interval (e.g. once a week/month). The new signed prekey
     // and prekey signature will replace the previous values.
 
+    // FIXME: It this pub/priv keys or priv and pub-signed? 
+    
     // Bob's signed prekey `SPK_B`
     let bob_spk_secret = X25519SecretKey::new(OsRng);
-    let bob_spk_public = X25519PublicKey::from(&bob_spk_secret);
+    let bob_public_spk = X25519PublicKey::from(&bob_spk_secret);
 
     // Bob's prekey signature `Sig(IK_b, Encode(SPK_B))`
     let nonce = [0_u8; 64];
-    //let bob_spk_signature = bob_ik_secret.xeddsa_sign(&bob_spk_public.to_bytes(), &nonce);
-    let bob_spk_signature = bob_ik_secret.xeddsa_sign(&bob_spk_public.to_bytes(), &nonce);
+    //let bob_spk_signature = bob_ik_secret.xeddsa_sign(&bob_public_spk.to_bytes(), &nonce);
+   
+    //FIXME: what's the corrrect key? bob_spk_secret.xddsa or bob_ik_secret.xddsa ?
+    let bob_spk_signature = bob_spk_secret.xeddsa_sign(&bob_public_spk.to_bytes(), &nonce);
 
     // A set of Bob's one-time prekeys `(OPK_B1, OPK_B2, OPK_B3, ...)`
     let mut bob_opk_secrets =
@@ -468,7 +472,7 @@ fn main() {
     bob_opk_publics.push_back(X25519PublicKey::from(&bob_opk_secrets[2]));
 
     let bob_keyset = Keyset {
-        signed_prekey: bob_spk_public,
+        signed_prekey: bob_public_spk,
         prekey_signature: bob_spk_signature,
         onetime_prekeys: bob_opk_publics.clone(),
     };

--- a/script/research/x3dh/src/main.rs
+++ b/script/research/x3dh/src/main.rs
@@ -485,6 +485,12 @@ fn main() {
 
     // Alice verifies the prekey signature and aborts the protocol if
     // verification fails.
+
+    println!("\n{:?}", bob_keyset.signed_prekey.to_bytes().clone());
+    println!("{:?}", bob_keyset.signed_prekey.to_bytes().clone().len());
+    println!("\n{:?}", bob_keyset.prekey_signature.clone());
+    println!("{:?}", bob_keyset.prekey_signature.clone().len());
+
     assert!(bob_keyset
         .identity_key
         .xeddsa_verify(&bob_keyset.signed_prekey.to_bytes(), &bob_keyset.prekey_signature));

--- a/script/research/x3dh/src/main.rs
+++ b/script/research/x3dh/src/main.rs
@@ -450,7 +450,6 @@ fn main() {
     // at some interval (e.g. once a week/month). The new signed prekey
     // and prekey signature will replace the previous values.
 
-    // FIXME: It this pub/priv keys or priv and pub-signed? 
     
     // Bob's signed prekey `SPK_B`
     let bob_spk_secret = X25519SecretKey::new(OsRng);
@@ -458,10 +457,8 @@ fn main() {
 
     // Bob's prekey signature `Sig(IK_b, Encode(SPK_B))`
     let nonce = [0_u8; 64];
-    //let bob_spk_signature = bob_ik_secret.xeddsa_sign(&bob_public_spk.to_bytes(), &nonce);
+    let bob_spk_signature = bob_ik_secret.xeddsa_sign(&bob_public_spk.to_bytes(), &nonce);
    
-    //FIXME: what's the corrrect key? bob_spk_secret.xddsa or bob_ik_secret.xddsa ?
-    let bob_spk_signature = bob_spk_secret.xeddsa_sign(&bob_public_spk.to_bytes(), &nonce);
 
     // A set of Bob's one-time prekeys `(OPK_B1, OPK_B2, OPK_B3, ...)`
     let mut bob_opk_secrets =

--- a/script/research/x3dh/src/xeddsa.rs
+++ b/script/research/x3dh/src/xeddsa.rs
@@ -52,11 +52,11 @@ impl XeddsaSigner for X25519SecretKey {
         // x25519-dalek private keys are already clamped, so just compute
         // the Ed25519 public key from the Curve25519 private key.
         let scalar_k = Scalar::from_bits(self.to_bytes());
-        let ep = ED25519_BASEPOINT_POINT * scalar_k;
-        let mut ce = ep.compress();
-        let sign = ce.0[31] >> 7;
+        let edward_point = ED25519_BASEPOINT_POINT * scalar_k;
+        let mut compressed_edwards = edward_point.compress();
+        let sign = compressed_edwards.0[31] >> 7;
         // Set the sign bit to zero after adjusting the private key
-        ce.0[31] &= 0x7F; // A.s = 0
+        compressed_edwards.0[31] &= 0x7F; // A.s = 0
 
         // Compute the negative secret key
 
@@ -73,7 +73,7 @@ impl XeddsaSigner for X25519SecretKey {
         // directly, but rather use a seed to derive other data from.
         // To create signatures compatible with Ed25519, a modified
         // version of the signing algorithm is required that does not
-        // depend on a seed.
+        // dedward_pointend on a seed.
         // r = hash1(a || M || Z) (mod q)
         let mut hash_padding = [0xff, 32];
         hash_padding[0] = 0xfe;
@@ -90,7 +90,7 @@ impl XeddsaSigner for X25519SecretKey {
         // h = hash(R || A || M) (mod q)
         hasher = Sha512::new();
         hasher.update(cap_r.as_bytes());
-        hasher.update(ce.as_bytes());
+        hasher.update(compressed_edwards.as_bytes());
         hasher.update(msg);
         let h = Scalar::from_hash(hasher);
 

--- a/script/research/x3dh/src/xeddsa.rs
+++ b/script/research/x3dh/src/xeddsa.rs
@@ -22,8 +22,8 @@ use curve25519_dalek::{
     constants::ED25519_BASEPOINT_POINT, montgomery::MontgomeryPoint, scalar::Scalar,
 };
 use digest::Digest;
-use ed25519_dalek::{Signature, SigningKey as Ed25519PublicKey};
 use sha2::Sha512;
+use ed25519_dalek::{Signature, VerifyingKey as Ed25519PublicKey};
 use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519SecretKey};
 
 pub trait XeddsaSigner {
@@ -110,9 +110,9 @@ impl XeddsaVerifier for X25519PublicKey {
         let pt = MontgomeryPoint(self.to_bytes());
 
         if let Some(edwards) = pt.to_edwards(0) {
-            let pk = Ed25519PublicKey::from_bytes(&edwards.compress().to_bytes());
+            let pk = Ed25519PublicKey::from_bytes(&edwards.compress().to_bytes()).unwrap();
             let signature = Signature::from_bytes(sig);
-            return pk.verify(msg, &signature).is_ok()
+            return pk.verify_strict(msg, &signature).is_ok()
         }
 
         false
@@ -128,7 +128,7 @@ mod tests {
     fn xeddsa_test() {
         let nonce = [0u8; 64];
         let msg = [0u8; 200];
-
+ 
         let xsecret_key = X25519SecretKey::new(&mut OsRng);
         let xpublic_key = X25519PublicKey::from(&xsecret_key);
 

--- a/script/research/x3dh/src/xeddsa.rs
+++ b/script/research/x3dh/src/xeddsa.rs
@@ -111,8 +111,8 @@ impl XeddsaVerifier for X25519PublicKey {
 
         if let Some(edwards) = pt.to_edwards(0) {
             let pk = Ed25519PublicKey::from_bytes(&edwards.compress().to_bytes());
-            let sig = Signature::from_bytes(sig);
-            return pk.verify(msg, &sig).is_ok()
+            let signature = Signature::from_bytes(sig);
+            return pk.verify(msg, &signature).is_ok()
         }
 
         false


### PR DESCRIPTION
Fixes signature verification after crate downgrade.
Most relevat change was the import:
```rust
use ed25519_dalek::{Signature, SigningKey as Ed25519PublicKey};
```
to
```rust
use ed25519_dalek::{Signature, VerifyingKey as Ed25519PublicKey};
```

Lastly, the `.verify()` method was updated to `verify_strict()` since the latter performs maleability checks (`ed25519-dalek-2.0.0-pre.0/src/verifying.rs:299`)