### PR TITLE
build: use cargo home as install prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 
 # Install prefix
-PREFIX = /usr/local
+PREFIX = $(HOME)/.cargo
 
 # Cargo binary
 CARGO = cargo


### PR DESCRIPTION
this avoids requiring escalated system privileges to install the binaries.

ref: https://doc.rust-lang.org/cargo/guide/cargo-home.html