### PR TITLE
[example] fix outdated link and filename in README

### DIFF
--- a/example/dchat/README.md
+++ b/example/dchat/README.md
@@ -2,14 +2,14 @@
 
 A demo chat program to document DarkFi net
 code. Tutorial can be found in the [DarkFi
-book](https://darkrenaissance.github.io/darkfi/learn/writing-a-p2p-app.html).
+book](https://darkrenaissance.github.io/darkfi/learn/dchat/dchat.html).
 
 ## Usage
 
 Spin up a seed node:
 
 ```shell
-cd example/dchat-seed
+cd example/dchat
 cargo run
 ```
 


### PR DESCRIPTION
The correct link to the tutorial is https://darkrenaissance.github.io/darkfi/learn/dchat/dchat.html

- Fixed outdated link so it no longer gives 404
- Updated folder name from `dchat-seed` to `dchat`