### PR TITLE
[docs] fix rustdoc 404 due to ircd name change

### DIFF
--- a/doc/src/development/rustdoc.md
+++ b/doc/src/development/rustdoc.md
@@ -18,7 +18,7 @@ Here the rustdoc for this repository's crates can be found.
 * [`faucetd`](faucetd/index.html)
 * [`fu`](fu/index.html)
 * [`fud`](fud/index.html)
-* [`ircd`](ircd/index.html)
+* [`darkirc`](darkirc/index.html)
 * [`lilith`](lilith/index.html)
 * [`tau`](tau/index.html)
 * [`taud`](taud/index.html)


### PR DESCRIPTION
The link for `ircd` on this page gives a 404: https://darkrenaissance.github.io/darkfi/development/rustdoc.html

The correct link is https://darkrenaissance.github.io/darkfi/development/darkirc/index.html