### PR TITLE
book: clarify network privacy for irc

### DIFF
--- a/doc/src/misc/ircd/ircd.md
+++ b/doc/src/misc/ircd/ircd.md
@@ -195,3 +195,13 @@ inbound and outbound connections.
 Copy [this script](https://github.com/narodnik/weechat-global-buffer/blob/main/buffclone.py) to `~/.weechat/python/autoload/`,
 and you will create a single buffer which aggregates messages from all channels. It's useful to monitor activity
 from all channels without needing to flick through them.
+
+## Network-level privacy
+
+Nodes have knowledge of their peers, including the IP addresses of connected hosts.
+
+DarkFi supports the use of pluggable transports, including Tor and Nym, to provide network-level privacy. As long as there
+are live seed nodes configured to support a Tor or Nym connection, users can connect to `darkirc` and benefit from the
+protections offered by these protocols.
+
+Other approaches include connecting via a cloud server or VPN. Research the risks involved in these methods before connecting.


### PR DESCRIPTION
Goals:
- Make it explicit that IP address is exposed by default
- Mention the support of Tor/Nym while also clarifying that seed nodes need to support these connection methods for users to actually use them
- Mention VPS/VPN connections as an option, but discourage blind usage 