### PR TITLE
Added sqllite3 dependency for Debian-based systems to dependency_setup.sh

### DIFF
--- a/contrib/dependency_setup.sh
+++ b/contrib/dependency_setup.sh
@@ -22,7 +22,7 @@ setup_mac() {
 }
 
 setup_apt() {
-	apt_deps="git make gcc pkg-config libasound2-dev libssl-dev libsqlcipher-dev"
+	apt_deps="git make gcc pkg-config libasound2-dev libssl-dev libsqlcipher-dev libsqlite3-dev"
 	$1 install $apt_deps || return 1
 }
 


### PR DESCRIPTION
Added sqllite3 dependency for Debian-based systems to dependency_setup.sh.
This dependency must have been added with recent functionality updates.