### PR TITLE
Fixed for broken "make install" following recent refactorings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ BINS = \
 	genev/genev-cli \
 	genev/genevd \
 	lilith \
-	tau \
-	taud \
+	tau/tau-cli \
+	tau/taud \
 	vanityaddr
 
 # ZK proofs to compile with zkas

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ distclean: clean
 install: $(BINS)
 	@for i in $(BINS); \
 	do \
-		echo $(MAKE) -C bin/$$i install; \
+		$(MAKE) -C bin/$$i install; \
 	done;
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ BINS = \
 	darkfid2 \
 	faucetd \
 	darkirc \
-	genev \
-	genevd \
+	genev/genev-cli \
+	genev/genevd \
 	lilith \
 	tau \
 	taud \
@@ -116,16 +116,16 @@ distclean: clean
 	$(CARGO) clean
 	rm -rf target
 
-install: all
+install: $(BINS)
 	@for i in $(BINS); \
 	do \
-		$(MAKE) -C $$i install \
+		echo $(MAKE) -C bin/$$i install; \
 	done;
 
 uninstall:
 	for i in $(BINS); \
 	do \
-		$(MAKE) -C $$i uninstall \
+		$(MAKE) -C bin/$$i uninstall; \
 	done;
 
 .PHONY: all contracts check fix fmt clippy rustdoc test coverage distclean clean install uninstall $(BINS)


### PR DESCRIPTION
Fixed for broken "make install" following recent refactorings.  A mixture of typos and irregular nesting for genev executables.