### PR TITLE
util: fix division-by-zero panics

### DIFF
--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -297,7 +297,7 @@ pub fn timestamp_to_date(timestamp: u64, format: DateFormat) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{Timestamp, TimeKeeper};
+    use super::{TimeKeeper, Timestamp};
 
     #[test]
     fn zero_values_are_safe() {
@@ -305,7 +305,7 @@ mod tests {
         // Certain functions above use division so a panic can occur
         // if division-by-zero is performed.
         let ts = Timestamp::current_time();
-        let tk = TimeKeeper::new(ts,0,0,0);
+        let tk = TimeKeeper::new(ts, 0, 0, 0);
         // Try all TimeKeeper functions that use division.
         tk.current_epoch();
         tk.slot_epoch(0);

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -56,7 +56,7 @@ impl TimeKeeper {
         Self { genesis_ts, epoch_length, slot_time, verifying_slot }
     }
 
-    /// Generate a Timekeeper for current slot
+    /// Generate a TimeKeeper for current slot
     pub fn current(&self) -> Self {
         Self {
             genesis_ts: self.genesis_ts,
@@ -153,7 +153,7 @@ impl TimeKeeperSafe {
         }
         Self { timekeeper: TimeKeeper { genesis_ts, epoch_length, slot_time, verifying_slot } }
     }
-    /// Generate a TimekeeperSafe for current slot
+    /// Generate a TimeKeeperSafe for current slot
     pub fn current(&self) -> TimeKeeperSafe {
         TimeKeeperSafe::new(
             self.timekeeper.genesis_ts,

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -175,16 +175,25 @@ impl TimeKeeperSafe {
     /// epoch 1 has one less slot(the genesis slot) and
     /// rest epoch have the normal amount of slots.
     pub fn slot_epoch(&self, slot: u64) -> u64 {
+        if self.timekeeper.epoch_length == 0 {
+            panic!("Epoch length cannot be zero");
+        }
         self.timekeeper.slot_epoch(slot)
     }
 
     /// Calculates current slot, based on elapsed time from the genesis block.
     pub fn current_slot(&self) -> u64 {
+        if self.timekeeper.slot_time == 0 {
+            panic!("Slot time cannot be zero");
+        }
         self.timekeeper.current_slot()
     }
 
     /// Calculates the relative number of the provided slot.
     pub fn relative_slot(&self, slot: u64) -> u64 {
+        if self.timekeeper.epoch_length == 0 {
+            panic!("Epoch length cannot be zero");
+        }
         self.timekeeper.relative_slot(slot)
     }
 
@@ -382,7 +391,7 @@ pub fn timestamp_to_date(timestamp: u64, format: DateFormat) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{TimeKeeperSafe, Timestamp};
+    use super::{TimeKeeper, TimeKeeperSafe, Timestamp};
 
     #[test]
     #[should_panic]
@@ -395,5 +404,32 @@ mod tests {
     #[should_panic]
     fn panic_on_unsafe_slot_time() {
         TimeKeeperSafe::new(Timestamp::current_time(), 1, 0, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn panic_on_unsafe_call_to_method_current_slot() {
+        // Test against manual initialization of unsafe TimeKeeper fields.
+        let tk_unsafe =
+            TimeKeeperSafe { timekeeper: TimeKeeper::new(Timestamp::current_time(), 0, 0, 0) };
+        tk_unsafe.current_slot();
+    }
+
+    #[test]
+    #[should_panic]
+    fn panic_on_unsafe_call_to_method_relative_slot() {
+        // Test against manual initialization of unsafe TimeKeeper fields.
+        let tk_unsafe =
+            TimeKeeperSafe { timekeeper: TimeKeeper::new(Timestamp::current_time(), 0, 0, 0) };
+        tk_unsafe.relative_slot(0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn panic_on_unsafe_call_to_method_slot_epoch() {
+        // Test against manual initialization of unsafe TimeKeeper fields.
+        let tk_unsafe =
+            TimeKeeperSafe { timekeeper: TimeKeeper::new(Timestamp::current_time(), 0, 0, 0) };
+        tk_unsafe.slot_epoch(0);
     }
 }

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -30,8 +30,10 @@ const MIN_IN_HOUR: u64 = 60;
 const SECS_IN_HOUR: u64 = 3600;
 
 /// Helper structure providing time related calculations.
-/// This struct is optimized for performance and does not check
-/// its arithmetic: division-by-zero is possible for certain values.
+/// This struct is optimized for performance. The developer is responsible
+/// for ensuring `slot_time` and `epoch_length` are greater than 0.
+/// Values of 0 for these fields are incoherent and unsafe in asynchronous
+/// context.
 /// [`TimeKeeperSafe`] should be used if safety is more important than
 /// performance.
 #[derive(Clone)]

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -159,7 +159,7 @@ impl TimeKeeperSafe {
             self.timekeeper.genesis_ts,
             self.timekeeper.epoch_length,
             self.timekeeper.slot_time,
-            self.timekeeper.current_slot(),
+            self.timekeeper.verifying_slot,
         )
     }
 

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -78,6 +78,9 @@ impl TimeKeeper {
     /// epoch 1 has one less slot(the genesis slot) and
     /// rest epoch have the normal amount of slots.
     pub fn slot_epoch(&self, slot: u64) -> u64 {
+        if slot == 0 {
+            return 0
+        }
         (slot / self.epoch_length) + 1
     }
 


### PR DESCRIPTION
Added checks for division by zero by creating a TimeKeeperSafe struct