### PR TITLE
Fix ARM rust nightly issue in pathfinder_simd Stop using old-style simd_shuffle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,3 +315,5 @@ halo2_gadgets = {git="https://github.com/parazyd/halo2", branch="v4"}
 arti-client = {git="https://gitlab.torproject.org/tpo/core/arti", rev="3fdadcc7509f60cfdfc51df2664aaf2f73bbd2f0"}
 tor-hscrypto = {git="https://gitlab.torproject.org/tpo/core/arti", rev="3fdadcc7509f60cfdfc51df2664aaf2f73bbd2f0"}
 blake2b_simd = {git="https://github.com/parazyd/blake2_simd", branch="impl-common"}
+# fix ARM rust nightly issue https://github.com/servo/pathfinder/pull/542 Stop using old-style simd_shuffle
+pathfinder_simd = {git="https://github.com/servo/pathfinder", rev="38709546b32bc1d4489c6332045363602c3e8f88"}


### PR DESCRIPTION
Fixes ARM to compile, but the test on ARM fails when multithreading enabled (default).
Tested on f3c604acc Fri Sep 8 13:58:10 2023 +0200
Tests and builds fine on x64.
```
on NanoPC-T6 ARM worked as:
~/darkfi$ time cargo test -p darkfid2 --bin darkfid2 --release -- --test-threads=1
    Finished release [optimized] target(s) in 0.60s
     Running unittests src/main.rs (target/release/deps/darkfid2-f9b8cc71e489e83d)

running 2 tests
test tests::forks::forks ... ok
test tests::sync_blocks ... 
...
10:38:12 [INFO] [WASM] Contract log: [ConsensusStakeV1] Adding new coin to the set
10:38:12 [INFO] [WASM] Contract log: [ConsensusStakeV1] Adding new coin to the Merkle tree
10:38:12 [INFO] Gas used: 34495910/400000000
10:38:12 [INFO] Instantiating a new runtime
10:38:12 [INFO] Gas used: 6017741/400000000
10:38:12 [INFO] Gas used: 36907718/400000000
10:38:12 [INFO] [WASM] Contract log: [MintV1] Adding new coin to the set
10:38:12 [INFO] [WASM] Contract log: [MintV1] Adding new coin to the Merkle tree
10:38:12 [INFO] Gas used: 36936663/400000000
ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 496.85s


real    8m17.862s
user    30m14.499s
sys     0m11.044s

===
but with multithreading run fails

time cargo test -p darkfid2 --bin darkfid2 --release
...
16:42:40 [INFO] [WASM] Contract log: [ConsensusStakeV1] Adding new coin to the Merkle tree
16:42:40 [INFO] Gas used: 34458734/400000000
16:42:40 [INFO] Instantiating a new runtime
16:42:40 [INFO] Gas used: 6017741/400000000
16:42:41 [INFO] Gas used: 36870542/400000000
16:42:41 [INFO] [WASM] Contract log: [MintV1] Adding new coin to the set
16:42:41 [INFO] [WASM] Contract log: [MintV1] Adding new coin to the Merkle tree
16:42:41 [INFO] Gas used: 36899487/400000000
test tests::sync_blocks ... FAILED

failures:

---- tests::sync_blocks stdout ----
thread 'tests::sync_blocks' panicked at bin/darkfid2/src/tests/harness.rs:139:9:
assertion `left == right` failed
  left: 3
 right: 2
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::sync_blocks

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 348.29s

error: test failed, to rerun pass `-p darkfid2 --bin darkfid2`
make: *** [Makefile:92: test] Error 101

real    52m54.383s

... other cases ...
...
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4466.90s

error: test failed, to rerun pass `-p darkfid2 --bin darkfid2`

real    74m28.268s
user    270m23.963s
sys     0m12.634s

```
