### PR TITLE
zkas: Fix compiler panic when semicolons are missing

### DIFF
--- a/src/zkas/compiler.rs
+++ b/src/zkas/compiler.rs
@@ -111,8 +111,7 @@ impl Compiler {
                 StatementType::Assign => tmp_heap.push(&i.lhs.as_ref().unwrap().name),
                 // In case of a simple call, we don't append anything to the heap
                 StatementType::Call => {}
-                // TODO: FIXME: unreachable is reached with missing semicolons in the code
-                _ => unreachable!(),
+                _ => unreachable!("Invalid statement type in circuit: {:?}", i.typ),
             }
 
             bincode.push(i.opcode as u8);

--- a/src/zkas/parser.rs
+++ b/src/zkas/parser.rs
@@ -890,6 +890,14 @@ impl Parser {
                     ))
                 }
 
+                if stmt.typ == StatementType::Noop {
+                    return Err(self.error.abort(
+                        "Statement is a NOOP; not allowed. (Did you miss a semicolon?)",
+                        token.line,
+                        token.column,
+                    ))
+                }
+
                 ret.push(stmt);
                 stmt = Statement::default();
             }

--- a/src/zkas/parser.rs
+++ b/src/zkas/parser.rs
@@ -890,6 +890,11 @@ impl Parser {
                     ))
                 }
 
+                // At this stage of parsing, we should have assigned `stmt` a StatementType that is
+                // not a Noop. If we have failed to do so, we cannot proceed because Nooops must
+                // never be pased to the compiler. This can occur when multiple independent
+                // statements are passed on one line, or if a statement is not terminated by a
+                // semicolon.
                 if stmt.typ == StatementType::Noop {
                     return Err(self.error.abort(
                         "Statement is a NOOP; not allowed. (Did you miss a semicolon?)",


### PR DESCRIPTION
Fixed a parser bug where it would pass invalid statements to the compiler which resulted in a panic.

Added error handling in the parser when a semicolon is missing. The error message suggests to the dev to add a semicolon.

Also added more detail to the unreachable()! statement in the compiler so that a darkfi dev can see what the erroneous StatementType was that caused the panic.

Example errror cases:

```
<statement> <statement>;
```

and
```
<statement>
<statement>;
```

To test: remove a semicolon from example/simple.zk and run ./zkas example/simple.zk