### PR TITLE
zkas: fix panics in Parser

### DIFF
--- a/src/zkas/parser.rs
+++ b/src/zkas/parser.rs
@@ -124,6 +124,10 @@ impl Parser {
         let mut ast_inner = IndexMap::new();
         let mut ast = IndexMap::new();
 
+        if self.tokens.len() == 0 {
+            return Err(self.error.abort("Source file does not contain any valid tokens.", 0, 0))
+        }
+
         if self.tokens[0].token_type != TokenType::Symbol {
             return Err(self.error.abort(
                 "Source file does not start with a section. Expected `constant/witness/circuit`.",
@@ -430,7 +434,10 @@ impl Parser {
 
         // Tokens have been processed and ast is complete
 
-        let ns = namespace.unwrap();
+        let ns = match namespace {
+            Some(v) => v,
+            None => return Err(self.error.abort("Missing namespace in .zk source.", 0, 0)),
+        };
         ast.insert(ns.clone(), ast_inner);
 
         let constants = {


### PR DESCRIPTION
Add error handling for the parser logic. Both of these issues were found via fuzzing.

Fix Panic 1: instead of panicking via unwrap() when analyzing the namespace, the parser displays an error message informing the .zk file author that they need to add a namespace.

Fix Panic 2: if the length of the `tokens` vector is 0, the parser now displays an error saying so.