### PR TITLE
zkas: Fix panics in analyzer

### DIFF
--- a/src/zkas/analyzer.rs
+++ b/src/zkas/analyzer.rs
@@ -270,18 +270,16 @@ impl Analyzer {
                                 v.column,
                             ))
                         }
-                    } else if arg_types[0] == VarType::ScalarArray {
-                        if var_type != VarType::Scalar {
-                            return Err(self.error.abort(
-                                &format!(
-                                    "Incorrect argument type. Expected `{:?}`, got `{:?}`.",
-                                    VarType::Scalar,
-                                    var_type
-                                ),
-                                v.line,
-                                v.column,
-                            ))
-                        }
+                    } else if arg_types[0] == VarType::ScalarArray && var_type != VarType::Scalar {
+                        return Err(self.error.abort(
+                            &format!(
+                                "Incorrect argument type. Expected `{:?}`, got `{:?}`.",
+                                VarType::Scalar,
+                                var_type
+                            ),
+                            v.line,
+                            v.column,
+                        ))
                     }
                     // Validation for non-Array types
                     if var_type != arg_types[idx] {

--- a/src/zkas/analyzer.rs
+++ b/src/zkas/analyzer.rs
@@ -186,6 +186,8 @@ impl Analyzer {
 
                     let mut rhs_inner = vec![];
                     for (inner_idx, i) in func.rhs.iter().enumerate() {
+                        // TODO: Implement cases where `i` is type Arg::Literal
+                        // TODO: Implement cases where `i` is type Arg::Func
                         if let Arg::Var(v) = i {
                             if let Some(var_ref) = self.lookup_var(&v.name) {
                                 let (var_type, ln, col) = match var_ref {
@@ -218,8 +220,20 @@ impl Analyzer {
                                 v.line,
                                 v.column,
                             ))
+                        } else if let Arg::Lit(l) = i {
+                            return Err(self.error.abort(
+                                &format!("Expected argument `{}` to be of type Variable. Literals are not yet supported in nested function calls.", l.name),
+                                l.line,
+                                l.column,
+                            ))
+                        } else if let Arg::Func(f) = i {
+                            return Err(self.error.abort(
+                                &format!("Expected argument `{}` to be of type Variable. Nested function calls are not yet supported beyond a depth of 1.", Opcode::name(&f.opcode)),
+                                f.line,
+                                0,
+                            ))
                         } else {
-                            unimplemented!()
+                            unreachable!();
                         }
                     }
 

--- a/src/zkas/parser.rs
+++ b/src/zkas/parser.rs
@@ -124,7 +124,7 @@ impl Parser {
         let mut ast_inner = IndexMap::new();
         let mut ast = IndexMap::new();
 
-        if self.tokens.len() == 0 {
+        if self.tokens.is_empty() {
             return Err(self.error.abort("Source file does not contain any valid tokens.", 0, 0))
         }
 
@@ -1056,7 +1056,7 @@ impl Parser {
                     // x => unimplemented!("{:#?}", x),
                     _ => {
                         return Err(self.error.abort(
-                            &format!("Characer is illegal/unimplemented in this context",),
+                            "Character is illegal/unimplemented in this context",
                             arg.line,
                             arg.column,
                         ))


### PR DESCRIPTION
These issues were discovered with fuzzing.

Panic 1: It was possible to assign a variable to a function/opcode with
no return type. This caused a index-out-of-bounds panic when the
analyzer attempted to access the first element of an empty vector of
return types. The analyzer now presents an error when a .zk author
attempts to assign a variable to an opcode that has no return types.

Panic 2: There was an index-out-of-bounds panic when performing
verification on Literals that were passed to Opcodes that use Array
types as their arguments. This was fixed by pasting the validation code
from the Variable verfication section which handles Arrays properly.
(Refactoring should be done to reduce duplication here.)

Panic 3: Change the `unimplemented()!` panic macro to error handling that informs
the user that using Literals and Functions in nested function calls is
not yet supported. This should be a slightly more friendly developer
experience. Changing this from a panic to an error allows us to continue
with further fuzzing.