### PR TITLE
`zk::gadgets::less_than`: Support non-strict mode

### DIFF
--- a/src/zk/gadget/less_than.rs
+++ b/src/zk/gadget/less_than.rs
@@ -146,7 +146,7 @@ impl<const WINDOW_SIZE: usize, const NUM_OF_BITS: usize, const NUM_OF_WINDOWS: u
             },
         )?;
 
-        self.less_than_range_check(layouter, a, a_offset, strict)?;
+        self.less_than_range_check(layouter, a, a_offset)?;
 
         Ok(())
     }
@@ -194,7 +194,7 @@ impl<const WINDOW_SIZE: usize, const NUM_OF_BITS: usize, const NUM_OF_WINDOWS: u
             },
         )?;
 
-        self.less_than_range_check(layouter, a, a_offset, strict)?;
+        self.less_than_range_check(layouter, a, a_offset)?;
 
         Ok(())
     }
@@ -204,7 +204,6 @@ impl<const WINDOW_SIZE: usize, const NUM_OF_BITS: usize, const NUM_OF_WINDOWS: u
         mut layouter: impl Layouter<pallas::Base>,
         a: AssignedCell<pallas::Base, pallas::Base>,
         a_offset: AssignedCell<pallas::Base, pallas::Base>,
-        strict: bool,
     ) -> Result<(), Error> {
         let range_a_chip =
             NativeRangeCheckChip::<WINDOW_SIZE, NUM_OF_BITS, NUM_OF_WINDOWS>::construct(
@@ -215,13 +214,10 @@ impl<const WINDOW_SIZE: usize, const NUM_OF_BITS: usize, const NUM_OF_WINDOWS: u
                 self.config.range_a_offset_config.clone(),
             );
 
-        range_a_chip.copy_range_check(layouter.namespace(|| "a copy_range_check"), a, strict)?;
+        range_a_chip.copy_range_check(layouter.namespace(|| "a copy_range_check"), a)?;
 
-        range_a_offset_chip.copy_range_check(
-            layouter.namespace(|| "a_offset copy_range_check"),
-            a_offset,
-            strict,
-        )?;
+        range_a_offset_chip
+            .copy_range_check(layouter.namespace(|| "a_offset copy_range_check"), a_offset)?;
 
         Ok(())
     }

--- a/src/zk/gadget/less_than.rs
+++ b/src/zk/gadget/less_than.rs
@@ -16,6 +16,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+//! Given two values:
+//!     - `a`, a NUM_OF_BITS-length value and
+//!     - `b`, an arbitrary field element,
+//! this gadget constrains them in the following way:
+//!     - in `strict` mode, `a` is constrained to be strictly less than `b`;
+//!     - else, `a` is constrained to be less than or equal to `b`.
+
 use halo2_proofs::{
     arithmetic::Field,
     circuit::{AssignedCell, Chip, Layouter, Region, Value},
@@ -338,6 +345,7 @@ mod tests {
             (pallas::Base::from(13), pallas::Base::from(15)),
             (pallas::Base::ZERO, pallas::Base::from(u64::MAX)),
             (pallas::Base::ONE, pallas::Base::from(rand::random::<u64>())),
+            (pallas::Base::from(u64::MAX), pallas::Base::from(u64::MAX) + pallas::Base::ONE),
         ];
 
         let invalid_pairs = [
@@ -347,7 +355,6 @@ mod tests {
             (pallas::Base::ONE, pallas::Base::ONE),
             (pallas::Base::ONE, pallas::Base::ZERO),
             (pallas::Base::from(u64::MAX), pallas::Base::from(u64::MAX)),
-            //FIXME: (pallas::Base::from(u64::MAX), pallas::Base::from(u64::MAX) + pallas::Base::ONE),
         ];
 
         use plotters::prelude::*;
@@ -403,7 +410,7 @@ mod tests {
             ),
             (MAX_253 - pallas::Base::from(2), MAX_253 - pallas::Base::ONE),
             (MAX_253 - pallas::Base::ONE, MAX_253),
-            (MAX_253, MAX_253 + pallas::Base::ONE), // <-- Is this legit??
+            (MAX_253, MAX_253 + pallas::Base::ONE),
         ];
 
         let invalid_pairs = [

--- a/src/zk/gadget/native_range_check.rs
+++ b/src/zk/gadget/native_range_check.rs
@@ -397,6 +397,21 @@ mod tests {
 
     // cargo test --release --all-features --lib native_range_check -- --nocapture
     #[test]
+    fn native_range_check_2() {
+        let k = 6;
+        const WINDOW_SIZE: usize = 5;
+        const NUM_BITS: usize = 2;
+        const NUM_WINDOWS: usize = 1;
+
+        // [0, 1, 2, 3]
+        let valid_values: Vec<_> = (0..(1 << NUM_BITS)).map(pallas::Base::from).collect();
+        // [4, 5, 6, ..., 32]
+        let invalid_values: Vec<_> =
+            ((1 << NUM_BITS)..=(1 << WINDOW_SIZE)).map(pallas::Base::from).collect();
+        test_circuit!(k, WINDOW_SIZE, NUM_BITS, NUM_WINDOWS, valid_values, invalid_values);
+    }
+
+    #[test]
     fn native_range_check_64() {
         let k = 6;
         const WINDOW_SIZE: usize = 3;

--- a/src/zk/gadget/native_range_check.rs
+++ b/src/zk/gadget/native_range_check.rs
@@ -120,8 +120,8 @@ impl<const WINDOW_SIZE: usize, const NUM_BITS: usize, const NUM_WINDOWS: usize>
         let bits: Vec<bool> = value
             .to_le_bits()
             .into_iter()
-            .take(NUM_BITS)
-            .chain(std::iter::repeat(false).take(padding))
+            .take(WINDOW_SIZE * NUM_WINDOWS)
+            // .chain(std::iter::repeat(false).take(padding))
             .collect();
         assert_eq!(bits.len(), NUM_BITS + padding);
 
@@ -290,6 +290,7 @@ mod tests {
     // cargo test --release --all-features --lib native_range_check -- --nocapture
     #[test]
     fn native_range_check_64() {
+        // FIXME: constrains values to be 22 * 3 = 66 bits, not 64 bits
         test_circuit!(3, 64, 22);
         let k = 6;
 
@@ -302,8 +303,10 @@ mod tests {
 
         let invalid_values = vec![
             -pallas::Base::one(),
+            // FIXME: 1 << 64 passes since it is a 64-bit value
             pallas::Base::from_u128(u64::MAX as u128 + 1),
             -pallas::Base::from_u128(u64::MAX as u128 + 1),
+            // FIXME: this test may pass non-deterministically
             pallas::Base::from_u128(rand::random::<u128>()),
             // The following two are valid
             // 2 = -28948022309329048855892746252171976963363056481941560715954676764349967630335
@@ -346,6 +349,7 @@ mod tests {
 
     #[test]
     fn native_range_check_128() {
+        // FIXME: constrains values to be 43 * 3 = 129 bits, not 128 bits
         test_circuit!(3, 128, 43);
         let k = 7;
 
@@ -358,6 +362,7 @@ mod tests {
 
         let invalid_values = vec![
             -pallas::Base::one(),
+            // FIXME: 1 << 128 passes since it is a 129-bit value
             pallas::Base::from_u128(u128::MAX) + pallas::Base::one(),
             -pallas::Base::from_u128(u128::MAX) + pallas::Base::one(),
             -pallas::Base::from_u128(u128::MAX),
@@ -391,17 +396,19 @@ mod tests {
 
     #[test]
     fn native_range_check_253() {
+        // FIXME: constrains values to be 85 * 3 = 255 bits, not 253 bits
         test_circuit!(3, 253, 85);
         let k = 8;
+        // 2^253 - 1
+        let max_253 = pallas::Base::from_str_vartime(
+            "14474011154664524427946373126085988481658748083205070504932198000989141204991",
+        )
+        .unwrap();
 
         let valid_values = vec![
             pallas::Base::zero(),
             pallas::Base::one(),
-            // 2^253 - 1
-            pallas::Base::from_str_vartime(
-                "14474011154664524427946373126085988481658748083205070504932198000989141204991",
-            )
-            .unwrap(),
+            max_253,
             // 2^253 / 2
             pallas::Base::from_str_vartime(
                 "7237005577332262213973186563042994240829374041602535252466099000494570602496",
@@ -416,6 +423,8 @@ mod tests {
                 "28948022309329048855892746252171976963363056481941560715954676764349967630336",
             )
             .unwrap(),
+            // FIXME: 1 << 253 passes since it is a 255-bit value
+            max_253 + pallas::Base::one(),
         ];
 
         use plotters::prelude::*;

--- a/src/zk/vm.rs
+++ b/src/zk/vm.rs
@@ -1045,14 +1045,12 @@ impl Circuit<pallas::Base> for ZkCircuit {
                             rangecheck64_chip.as_ref().unwrap().copy_range_check(
                                 layouter.namespace(|| "copy range check 64"),
                                 arg.try_into()?,
-                                true,
                             )?;
                         }
                         253 => {
                             rangecheck253_chip.as_ref().unwrap().copy_range_check(
                                 layouter.namespace(|| "copy range check 253"),
                                 arg.try_into()?,
-                                true,
                             )?;
                         }
                         x => {


### PR DESCRIPTION
[review recommendation: commit-by-commit]

Introduces support for non-strict (`a ≤ b`) mode.

Based on #229; see [this commit range](https://github.com/darkrenaissance/darkfi/pull/230/files/04c64eed58e58e457ecac83eff4c6346bb442772..96c186725a2af643de784560f2a1646fd4c6d05c) for relevant diff. 