### PR TITLE
patch/aarch64_llvm_broken_fix_nightly-2023-11-19

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-11-19"


### PR DESCRIPTION
patch/aarch64_llvm_broken_fix_nightly-2023-11-19

no need to merge this one, just for help for ARM / aarch64 users

probably will be fixed soon, see

https://github.com/rust-lang/rust/issues/118124

1. need this first https://github.com/darkrenaissance/darkfi/pull/238
2. then this PR

No need to merge in, it can be used via `git apply` or `patch -p1` from https://github.com/darkrenaissance/darkfi/pull/<<PATCH_NUMBER>>.patch

