### PR TITLE
Added cmake and libclang-dev to the dependency_setup.sh

### DIFF
--- a/contrib/dependency_setup.sh
+++ b/contrib/dependency_setup.sh
@@ -22,7 +22,7 @@ setup_mac() {
 }
 
 setup_apt() {
-	apt_deps="git make gcc pkg-config libasound2-dev libssl-dev libsqlcipher-dev libsqlite3-dev"
+	apt_deps="git cmake make gcc pkg-config libasound2-dev libclang-dev libssl-dev libsqlcipher-dev libsqlite3-dev"
 	$1 install $apt_deps || return 1
 }
 


### PR DESCRIPTION
Added cmake and libclang-dev to the dependency_setup.sh for Debian/Ubuntu apt distros.  I needed these when building against a vanilla 23.10 Ubuntu installation.   Without these there was a build error while compiling the RandomX dependency.