### PR TITLE
stdsimd-removed-use-nightly-202402 in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-02-04"


### PR DESCRIPTION
For latest build ARM/x64

can be used via git apply or patch -p1 from https://github.com/darkrenaissance/darkfi/pull/<<PATCH_NUMBER>>.patch
