### PR TITLE
patch/curve25519-dalek_fix_to_4.1.1 as the newer breaks build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
 libc = "0.2.152"
 log = "0.4.20"
 thiserror = "1.0.56"
+curve25519-dalek = "=4.1.1"
 
 # async-runtime
 async-recursion = {version = "1.0.5", optional = true}


### PR DESCRIPTION
For latest build ARM/x64

can be used via git apply or patch -p1 from https://github.com/darkrenaissance/darkfi/pull/<<PATCH_NUMBER>>.patch
