### PR TITLE
load contract bytes at runtime in deploy_native_contracts

### DIFF
--- a/src/validator/utils.rs
+++ b/src/validator/utils.rs
@@ -50,23 +50,28 @@ pub async fn deploy_native_contracts(overlay: &BlockchainOverlayPtr) -> Result<(
     // The Deployooor contract uses an empty payload to deploy itself.
     let deployooor_contract_deploy_payload = vec![];
 
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set");
+    let money_contract_bytes = std::fs::read(format!("{manifest_dir}/src/contract/money/darkfi_money_contract.wasm"))?;
+    let dao_contract_bytes = std::fs::read(format!("{manifest_dir}/src/contract/dao/darkfi_dao_contract.wasm"))?;
+    let deployooor_contract_bytes = std::fs::read(format!("{manifest_dir}/src/contract/deployooor/darkfi_deployooor_contract.wasm"))?;
+
     let native_contracts = vec![
         (
             "Money Contract",
             *MONEY_CONTRACT_ID,
-            include_bytes!("../contract/money/darkfi_money_contract.wasm").to_vec(),
+            money_contract_bytes,
             money_contract_deploy_payload,
         ),
         (
             "DAO Contract",
             *DAO_CONTRACT_ID,
-            include_bytes!("../contract/dao/darkfi_dao_contract.wasm").to_vec(),
+            dao_contract_bytes,
             dao_contract_deploy_payload,
         ),
         (
             "Deployooor Contract",
             *DEPLOYOOOR_CONTRACT_ID,
-            include_bytes!("../contract/deployooor/darkfi_deployooor_contract.wasm").to_vec(),
+            deployooor_contract_bytes,
             deployooor_contract_deploy_payload,
         ),
     ];


### PR DESCRIPTION
using the `drk` crate as a dep in an external repo led to these compilation errors:
```
error: couldn't read `/home/e/.cargo/git/checkouts/darkfi-a258e322f5e79994/bfcd383/src/validator/../contract/money/darkfi_money_contract.wasm`: No such file or directory (os error 2)
  --> /home/e/.cargo/git/checkouts/darkfi-a258e322f5e79994/bfcd383/src/validator/utils.rs:57:13
   |
57 |             include_bytes!("../contract/money/darkfi_money_contract.wasm").to_vec(),
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)

error: couldn't read `/home/e/.cargo/git/checkouts/darkfi-a258e322f5e79994/bfcd383/src/validator/../contract/dao/darkfi_dao_contract.wasm`: No such file or directory (os error 2)
  --> /home/e/.cargo/git/checkouts/darkfi-a258e322f5e79994/bfcd383/src/validator/utils.rs:63:13
   |
63 |             include_bytes!("../contract/dao/darkfi_dao_contract.wasm").to_vec(),
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)

error: couldn't read `/home/e/.cargo/git/checkouts/darkfi-a258e322f5e79994/bfcd383/src/validator/../contract/deployooor/darkfi_deployooor_contract.wasm`: No such file or directory (os error 2)
  --> /home/e/.cargo/git/checkouts/darkfi-a258e322f5e79994/bfcd383/src/validator/utils.rs:69:13
   |
69 |             include_bytes!("../contract/deployooor/darkfi_deployooor_contract.wasm").to_vec(),
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)

```

the relative path used in `include_bytes` turned into `/src/validator/../contract/money/darkfi_money_contract.wasm` when darkfi is used as a lib, which is not a valid path.

this PR fixes the issue by loading the wasm bytes at runtime, using `CARGO_MANIFEST_DIR` to get a nonrelative path.

this was tested using a patch as follows + `make clippy`:
```
[patch."https://github.com/darkrenaissance/darkfi"]
darkfi = { git = "https://github.com/noot/darkfi", branch = "fix-include-bytes" }
```