### PR TITLE
darkirc:  allow empty IRC messages

### DIFF
--- a/bin/darkirc/src/irc/client.rs
+++ b/bin/darkirc/src/irc/client.rs
@@ -317,7 +317,8 @@ impl Client {
         W: AsyncWrite + Unpin,
     {
         if line.is_empty() || line == "\n" || line == "\r\n" {
-            return Err(Error::ParseFailed("Line is empty"))
+            // <https://www.rfc-editor.org/rfc/rfc1459> allows empty messages
+            return Ok(None); 
         }
 
         let mut line = line.to_string();


### PR DESCRIPTION
<https://www.rfc-editor.org/rfc/rfc1459> sez in "2.3.1 Message format in 'pseudo' BNF":

"[…] Empty messages are silently ignored, which permits use of the sequence CR-LF between messages without extra problems. […]"