### PR TITLE
Add support for colorizing zkas code samples in darkfi book

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -10,7 +10,7 @@ copy-fonts = true
 default-theme = "ayu"
 preferred-dark-theme = "ayu"
 theme = "theme"
-additional-js = ["theme/mermaid.min.js", "theme/mermaid-init.js"]
+additional-js = ["theme/mermaid.min.js", "theme/mermaid-init.js", "theme/zkas-highlight.js"]
 
 [output.html.playground]
 runnable = false

--- a/doc/src/arch/dao.md
+++ b/doc/src/arch/dao.md
@@ -15,7 +15,7 @@ these bullas.
 ## `DAO::mint()`: Establishing the DAO
 
 From `darkfi/src/contract/dao/proof/dao-mint.zk`:
-```
+```zkas
 	bulla = poseidon_hash(
 		dao_proposer_limit,
 		dao_quorum,
@@ -43,7 +43,7 @@ if desired.
 ## `DAO::propose()`: Propose the Vote
 
 From `darkfi/src/contract/dao/proof/dao-propose-main.zk`:
-```
+```zkas
 	proposal_bulla = poseidon_hash(
 		proposal_dest_x,
 		proposal_dest_y,
@@ -77,7 +77,7 @@ belong to the DAO and have the condition that they can only be spent
 when combined with `DAO::exec()`. Here is what coins in `money::transfer()`
 look like:
 
-```
+```zkas
 	C = poseidon_hash(
 		pub_x,
 		pub_y,

--- a/doc/src/crypto/rln.md
+++ b/doc/src/crypto/rln.md
@@ -126,13 +126,13 @@ $$ a_0 = \sum_{j=0}^{k-1} y_j \prod_{\begin{smallmatrix} m\,=\,0 \\ m\,\ne\,j \e
 
 ### Interaction
 
-```
+```zkas
 {{#include ../../../script/research/rln/rlnv1/signal.zk}}
 ```
 
 ### Slashing
 
-```
+```zkas
 {{#include ../../../script/research/rln/rlnv1/slash.zk}}
 ```
 

--- a/doc/src/dev/contrib/contrib.md
+++ b/doc/src/dev/contrib/contrib.md
@@ -143,7 +143,7 @@ _Tasks are in no particular order. Use common sense._
 25. ~~Python event viewer to inspect and debug the event graph.~~
 26. Fix `protocol_address` for anonymity. There is a loop sending self addr constantly. We should
     have this mixed with a bunch of random addrs to avoid leaking our own addr.
-27. Add support for colorizing zkas code samples in darkfi book (see arch/dao page)
+27. ~~Add support for colorizing zkas code samples in darkfi book (see arch/dao page)~~
 28. Tutorial creating a ZK credentials scheme.
 29. resource manager for p2p (DoS protection, disconnect bad nodes)
 30. apply DEP 0001

--- a/doc/src/zkas/examples/sapling.md
+++ b/doc/src/zkas/examples/sapling.md
@@ -10,7 +10,7 @@ $C$, and we use the burn proof to spend a previously minted _coin_.
 
 ## Mint proof
 
-```
+```zkas
 {{#include ../../../../proof/mint.zk}}
 ```
 
@@ -153,7 +153,7 @@ proof.verify(&verifying_key, &public_inputs)?;
 
 ## Burn
 
-```
+```zkas
 {{#include ../../../../proof/burn.zk}}
 ```
 

--- a/doc/src/zkas/examples/voting.md
+++ b/doc/src/zkas/examples/voting.md
@@ -14,7 +14,7 @@ with its voter's key on the database, so votes wouldn't be secret.
 
 ## Vote proof
 
-```
+```zkas
 {{#include ../../../../proof/voting.zk}}
 ```
 
@@ -47,4 +47,3 @@ zero-knowledge proof.
     [paper on Non-Interactive and
     Information-Theoretic Secure Verifiable Secret
     Sharing](https://link.springer.com/content/pdf/10.1007%2F3-540-46766-1_9.pdf)
-

--- a/doc/theme/zkas-highlight.js
+++ b/doc/theme/zkas-highlight.js
@@ -1,0 +1,25 @@
+hljs.registerLanguage("zkas", function (hljs) {
+  return {
+    name: "zkas",
+    case_insensitive: false,
+    keywords: {
+      keyword: "k field constant witness circuit",
+      literal: "true false VALUE_COMMIT_VALUE VALUE_COMMIT_RANDOM NULLIFIER_K",
+      type:
+        "EcPoint EcFixedPoint EcFixedPointBase EcFixedPointShort " +
+        "EcNiPoint Base BaseArray Scalar ScalarArray MerklePath Uint32 Uint64",
+      built_in:
+        "ec_add ec_mul ec_mul_base ec_mul_short ec_mul_var_base " +
+        "ec_get_x ec_get_y base_add base_mul base_sub poseidon_hash " +
+        "merkle_root range_check less_than_strict less_than_loose bool_check " +
+        "cond_select zero_cond witness_base constrain_equal_base " +
+        "constrain_equal_point constrain_instance debug",
+    },
+    contains: [
+      hljs.COMMENT("#", "$"),
+      hljs.QUOTE_STRING_MODE,
+      hljs.NUMBER_MODE,
+    ],
+  };
+});
+hljs.initHighlightingOnLoad();


### PR DESCRIPTION
## changes

- registered zkas as custom language in highlight.js

- i used the syntax highlighting rules in [zk.lang](https://github.com/darkrenaissance/darkfi/blob/master/contrib/zk.lang)

![Screenshot from 2024-11-19 21-11-45](https://github.com/user-attachments/assets/8cc48870-af1e-43ad-849b-d76642bfffd4)
