### PR TITLE
contrib/dependency_setup.sh: OS X: add wabt, change llvm

### DIFF
--- a/contrib/dependency_setup.sh
+++ b/contrib/dependency_setup.sh
@@ -15,7 +15,7 @@ setup_mac() {
 		bash -c "$(curl -fL "${brew_sh}")" || return 1
 	fi
 
-	for i in cmake gcc pkgconf llvm@13; do
+	for i in cmake gcc pkgconf wabt llvm; do
 		echo "Installing $i with brew..." >&2
 		brew install "$i" || return 1
 	done


### PR DESCRIPTION
Adds wabt for wasm-split
Versioned llvm no longer works in brew, resulting in: "Error: llvm@13 has been disabled because it is a versioned formula!"